### PR TITLE
Automatically save reverse manual routes

### DIFF
--- a/index.html
+++ b/index.html
@@ -689,16 +689,21 @@ const UI = {
       if(!latlngs || latlngs.length<2){ alert('Draw a polyline first.'); return; }
       const coords = latlngs.map(ll => [ll.lat, ll.lng]);
       const key=`${selO.value}|${selD.value}`;
+      const revKey=`${selD.value}|${selO.value}`;
+      const revCoords=[...coords].reverse();
       OverrideStore.set(key, coords);
+      OverrideStore.set(revKey, revCoords);
       showOverridePolyline(coords);
       clearNonOverrideDrawings();
-      alert('Override saved for ' + key);
+      alert('Override saved for ' + key + ' (and reverse)');
     });
     document.getElementById('btnClearOverride').addEventListener('click', ()=>{
       const key=`${selO.value}|${selD.value}`;
+      const revKey=`${selD.value}|${selO.value}`;
       OverrideStore.del(key);
+      OverrideStore.del(revKey);
       showOverridePolyline(null);
-      alert('Override cleared for ' + key);
+      alert('Override cleared for ' + key + ' (and reverse)');
     });
     document.getElementById('btnExportOverrides').addEventListener('click', ()=>{
       const data = OverrideStore.export();


### PR DESCRIPTION
## Summary
- Save drawn manual override routes for both directions using reversed coordinates
- Clear manual overrides in both directions with a single action

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68996cce6af48332bf130f8d7331fc0e