### PR TITLE
Add Node test harness

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+node_modules/

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,0 +1,13 @@
+{
+  "name": "truck_dispatch_sim",
+  "version": "1.0.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "truck_dispatch_sim",
+      "version": "1.0.0",
+      "license": "ISC"
+    }
+  }
+}

--- a/package.json
+++ b/package.json
@@ -1,0 +1,13 @@
+{
+  "name": "truck_dispatch_sim",
+  "version": "1.0.0",
+  "description": "",
+  "main": "index.js",
+  "scripts": {
+    "test": "node --test"
+  },
+  "keywords": [],
+  "author": "",
+  "license": "ISC",
+  "type": "module"
+}

--- a/test/utils.test.js
+++ b/test/utils.test.js
@@ -1,0 +1,13 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { haversineMiles, fmtETA } from '../src/utils.js';
+
+test('haversineMiles computes distance at equator for 1 degree', () => {
+  const dist = haversineMiles({lat:0, lng:0}, {lat:0, lng:1});
+  assert.ok(Math.abs(dist - 69.09) < 0.5);
+});
+
+test('fmtETA formats hours and minutes', () => {
+  const result = fmtETA(3720000);
+  assert.equal(result, '1h 2m');
+});


### PR DESCRIPTION
## Summary
- configure package.json with Node's built-in test runner
- add basic utility tests and ignore node_modules

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68aa2c721768833287fb8b6a44e594e1