### PR TITLE
Refresh load board on open to show drivers

### DIFF
--- a/src/load_board.js
+++ b/src/load_board.js
@@ -292,6 +292,9 @@ function setMode(mode){
 
 export function openLoadBoard(){
   if(!_panel) initLoadBoard();
+  // Always refresh the available loads so driver dropdowns include
+  // newly-added drivers on first open without requiring a manual refresh.
+  showAvailable();
   _panel.style.display='block';
   if(!_panel.style.top){ _panel.style.left='auto'; _panel.style.top='24px'; _panel.style.right='24px'; }
 }
@@ -311,7 +314,6 @@ export function initLoadBoard(){
   pruneCompleted();
   _panel = ensurePanel();
   _listEl = _panel.querySelector('#lb-list');
-  showAvailable();
   return _panel;
 }
 


### PR DESCRIPTION
## Summary
- Refresh available loads when the load board is opened so driver dropdowns include newly added drivers
- Avoid rendering the load board prematurely during init to prevent stale driver lists

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68aa2df0b36c8332bcd221c25517a7bc