### PR TITLE
Prevent route line disappearance when starting main load

### DIFF
--- a/src/driver.js
+++ b/src/driver.js
@@ -187,9 +187,10 @@ export class Driver {
     const add = 2 + Math.floor(Math.random()*3);
     this.hos[todayIdx] = Math.min(11, (this.hos[todayIdx]||0) + add);
     if (this.routeLine){
-      try{ this.routeLine.setStyle({opacity:0.3, dashArray:'4 6'});}catch(e){}
-      setTimeout(()=>{ try{ map.removeLayer(this.routeLine); }catch(e){} }, 4000);
-      this.routeLine=null;
+      const oldLine = this.routeLine;
+      this.routeLine = null;
+      try { oldLine.setStyle({ opacity:0.3, dashArray:'4 6' }); } catch(e){}
+      setTimeout(()=>{ try{ map.removeLayer(oldLine); }catch(e){} }, 4000);
     }
   }
 }


### PR DESCRIPTION
## Summary
- Preserve the active polyline when finishing deadhead segments so its delayed removal doesn't erase the next trip's route

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68aa3b0987908332a3f775d19aba6f16