### PR TITLE
Fix first-load driver availability check in load board

### DIFF
--- a/src/load_board.js
+++ b/src/load_board.js
@@ -233,8 +233,9 @@ function renderLoads(listEl, loads, mode='available'){
 
     if(mode==='available'){
       card.querySelector('.lb-book').addEventListener('click', ()=>{
-        if(!hasDrivers){ alert('No drivers available to assign.'); return; }
-        const sel=card.querySelector('.lb-driver'); const driverId=sel?.value;
+        const sel=card.querySelector('.lb-driver');
+        if(!sel || sel.options.length===0){ alert('No drivers available to assign.'); return; }
+        const driverId=sel.value;
         if(!driverId){ alert('Select a driver'); return; }
         bookLoad(L, driverId);
         // Optimistically remove this driver from ALL dropdowns


### PR DESCRIPTION
## Summary
- ensure "Book" button checks for driver options at click time to avoid false 'No drivers available' alerts on initial load

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68aa3f37a08c8332bcfa1694655d4f7b