### PR TITLE
Add dynamic truck and trailer market listings

### DIFF
--- a/index.html
+++ b/index.html
@@ -49,23 +49,7 @@
         <div>Market</div>
         <div class="close-x" data-close="#panelMarket">✕</div>
       </header>
-      <div class="content">
-        <h3>Buy Equipment</h3>
-        <div class="grid cols-2">
-          <div class="stat"><div class="small">Truck – Day Cab</div><div class="row"><div class="pill">$120,000</div><button class="btn" onclick="Game.buyEquipment('truck','Day Cab',120000)">Buy</button></div></div>
-          <div class="stat"><div class="small">Truck – Sleeper</div><div class="row"><div class="pill">$165,000</div><button class="btn" onclick="Game.buyEquipment('truck','Sleeper',165000)">Buy</button></div></div>
-          <div class="stat"><div class="small">Trailer – Dry Van</div><div class="row"><div class="pill">$42,000</div><button class="btn" onclick="Game.buyEquipment('trailer','Dry Van',42000)">Buy</button></div></div>
-          <div class="stat"><div class="small">Trailer – Reefer</div><div class="row"><div class="pill">$78,000</div><button class="btn" onclick="Game.buyEquipment('trailer','Reefer',78000)">Buy</button></div></div>
-        </div>
-
-        <h3 style="margin-top:14px;">Buy Property</h3>
-        <div class="grid cols-2">
-          <div class="stat"><div class="small">Small Yard – Dallas</div><div class="row"><div class="pill">$350,000</div><button class="btn" onclick="Game.buyProperty('Dallas Yard','Dallas, TX',350000)">Buy</button></div></div>
-          <div class="stat"><div class="small">Warehouse – Chicago</div><div class="row"><div class="pill">$1,200,000</div><button class="btn" onclick="Game.buyProperty('Chicago Warehouse','Chicago, IL',1200000)">Buy</button></div></div>
-        </div>
-
-      <div class="hint">Overhead increases per owned truck ($50/day) and per property ($200/day).</div>
-      </div>
+      <div class="content"></div>
     </div>
 
 


### PR DESCRIPTION
## Summary
- Populate the market panel dynamically with a catalog of purchasable trucks and trailers
- Support new and used equipment with randomized prices and day cab discounts
- Remove hardcoded market markup in favor of JS-rendered content

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b0f99046e88332b352adb1b92237bc