### PR TITLE
Widen market panel and limit height

### DIFF
--- a/assets/css/styles.css
+++ b/assets/css/styles.css
@@ -7,9 +7,11 @@ html, body { height: 100%; margin: 0; font-family: system-ui,-apple-system,Segoe
 .panel{position:absolute; left:12px; top:12px; width:380px; max-width:92vw; max-height:76vh; background:#0f1418; border:1px solid #2d3943; border-radius:10px; box-shadow:0 10px 32px rgba(0,0,0,.45); overflow:auto; z-index:600; display:none;}
 .panel header{position:sticky; top:0; background:#0f1418; padding:10px 12px; border-bottom:1px solid #21303a; font-weight:700; display:flex; justify-content:space-between; align-items:center; cursor:move;}
 .panel .content{padding:12px;}
+#panelMarket{width:900px; max-width:98vw; max-height:60vh;}
 .close-x{cursor:pointer; opacity:.8;}
 .grid{display:grid; gap:8px;}
 .grid.cols-2{grid-template-columns:1fr 1fr;}
+.grid.cols-3{grid-template-columns:1fr 1fr 1fr;}
 .stat{background:#101a20; border:1px solid #1e2a33; border-radius:8px; padding:8px 10px;}
 .small{font-size:12px; opacity:.8;}
 table{width:100%; border-collapse:collapse;}

--- a/src/ui_game.js
+++ b/src/ui_game.js
@@ -136,7 +136,7 @@ export const UI = {
     const content = panel.querySelector('.content'); if(!content) return;
     const rand = (min,max) => Math.round(Math.random()*(max-min)+min);
 
-    let html = '<h3>Buy Trucks</h3><div class="grid cols-2">';
+    let html = '<h3>Buy Trucks</h3><div class="grid cols-3">';
     TruckCatalog.forEach(t => {
       t.configs.forEach(cfg => {
         ['New','Used'].forEach(cond => {
@@ -148,7 +148,7 @@ export const UI = {
     });
     html += '</div>';
 
-    html += '<h3 style="margin-top:14px;">Buy Trailers</h3><div class="grid cols-2">';
+    html += '<h3 style="margin-top:14px;">Buy Trailers</h3><div class="grid cols-3">';
     TrailerCatalog.forEach(tr => {
       tr.types.forEach(type => {
         ['New','Used'].forEach(cond => {
@@ -162,7 +162,7 @@ export const UI = {
 
     html += `
       <h3 style="margin-top:14px;">Buy Property</h3>
-      <div class="grid cols-2">
+      <div class="grid cols-3">
         <div class="stat"><div class="small">Small Yard – Dallas</div><div class="row"><div class="pill">$350,000</div><button class="btn" onclick="Game.buyProperty('Dallas Yard','Dallas, TX',350000)">Buy</button></div></div>
         <div class="stat"><div class="small">Warehouse – Chicago</div><div class="row"><div class="pill">$1,200,000</div><button class="btn" onclick="Game.buyProperty('Chicago Warehouse','Chicago, IL',1200000)">Buy</button></div></div>
       </div>


### PR DESCRIPTION
## Summary
- Expand market panel to 900px wide and cap its height to 60vh.
- Switch market listings to a three-column grid for trucks, trailers, and properties.

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b12b8434b88332a37eb836a4d5e786