### PR TITLE
Widen market panel for better layout

### DIFF
--- a/assets/css/styles.css
+++ b/assets/css/styles.css
@@ -169,6 +169,18 @@ select, input[type="number"], input[type="text"]{width:100%; padding:8px; border
 }
 
 
+/* === Market panel wider layout === */
+#panelMarket {
+  width: 1000px !important;     /* longer horizontally */
+  max-width: 98vw !important;   /* responsive for small screens */
+  max-height: 60vh !important;  /* limit vertical size */
+}
+
+#panelMarket .grid.cols-2 {
+  grid-template-columns: repeat(auto-fill, minmax(220px, 1fr));
+}
+
+
 /* ===== Time HUD (clock + mini calendar + time controls) ===== */
 .time-hud{
   position: absolute;


### PR DESCRIPTION
## Summary
- Expand market panel to 1000px width and limit height for less vertical scroll
- Allow market grids to auto-fill multiple columns, shortening the panel vertically

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b12b8434b88332a37eb836a4d5e786