### PR TITLE
Add equipment and property panels to company view

### DIFF
--- a/index.html
+++ b/index.html
@@ -64,6 +64,24 @@
       </div>
     </div>
 
+    <!-- Equipment Panel -->
+    <div class="panel" id="panelEquipment">
+      <header>
+        <div>Equipment</div>
+        <div class="close-x" data-close="#panelEquipment">✕</div>
+      </header>
+      <div class="content"></div>
+    </div>
+
+    <!-- Properties Panel -->
+    <div class="panel" id="panelProperties">
+      <header>
+        <div>Properties</div>
+        <div class="close-x" data-close="#panelProperties">✕</div>
+      </header>
+      <div class="content"></div>
+    </div>
+
 
     <!-- Time HUD: clock + month calendar + time controls -->
     <div id="timeHud" class="time-hud">


### PR DESCRIPTION
## Summary
- add Equipment and Properties panels
- allow company panel buttons to open equipment and property listings
- refresh owned items after purchase
- keep company panel visible when viewing equipment or properties
- refine overlay logic for equipment/property panels

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b12f7e47288332a02a316866f7ac0a