### PR TITLE
feat: add driver hiring panel

### DIFF
--- a/src/driver.js
+++ b/src/driver.js
@@ -15,6 +15,9 @@ export class Driver {
       this.id = _driverIdCounter++;
       this.firstName = d.firstName || '';
       this.lastName = d.lastName || '';
+      this.age = d.age || 0;
+      this.gender = d.gender || '';
+      this.experience = Math.min(d.experience || 0, this.age);
       this.color = d.color || color || '#39c';
       this.lat = d.lat ?? lat ?? 0;
       this.lng = d.lng ?? lng ?? 0;
@@ -46,6 +49,9 @@ export class Driver {
       this.id = _driverIdCounter++;
       this.firstName = parts[0] || 'Driver';
       this.lastName = parts.slice(1).join(' ') || '';
+      this.age = 0;
+      this.gender = '';
+      this.experience = 0;
       this.color = color || '#39c';
       this.lat = lat || 0;
       this.lng = lng || 0;


### PR DESCRIPTION
## Summary
- replace add driver option with hire driver panel listing candidate details
- extend Driver model with age, gender and experience
- add Game logic to generate and hire drivers from candidate pool

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b1392766d883328ec5cf9c0069a3c0