### PR TITLE
feat: add driver hiring panel

### DIFF
--- a/src/data/driver_profiles.js
+++ b/src/data/driver_profiles.js
@@ -1,0 +1,12 @@
+export const DriverProfiles = [
+  { firstName: 'John', lastName: 'Smith', age: 45, gender: 'Male', experience: 20 },
+  { firstName: 'Jane', lastName: 'Doe', age: 34, gender: 'Female', experience: 10 },
+  { firstName: 'Carlos', lastName: 'Mendez', age: 50, gender: 'Male', experience: 25 },
+  { firstName: 'Alicia', lastName: 'Brown', age: 29, gender: 'Female', experience: 5 },
+  { firstName: 'Liam', lastName: 'Wilson', age: 40, gender: 'Male', experience: 15 },
+  { firstName: 'Olivia', lastName: 'Johnson', age: 38, gender: 'Female', experience: 12 },
+  { firstName: 'Noah', lastName: 'Davis', age: 27, gender: 'Male', experience: 3 },
+  { firstName: 'Ava', lastName: 'Garcia', age: 31, gender: 'Female', experience: 6 },
+  { firstName: 'Ethan', lastName: 'Martinez', age: 46, gender: 'Male', experience: 22 },
+  { firstName: 'Emma', lastName: 'Rodriguez', age: 36, gender: 'Female', experience: 11 }
+];

--- a/src/driver.js
+++ b/src/driver.js
@@ -15,6 +15,9 @@ export class Driver {
       this.id = _driverIdCounter++;
       this.firstName = d.firstName || '';
       this.lastName = d.lastName || '';
+      this.age = d.age || 0;
+      this.gender = d.gender || '';
+      this.experience = Math.min(d.experience || 0, this.age);
       this.color = d.color || color || '#39c';
       this.lat = d.lat ?? lat ?? 0;
       this.lng = d.lng ?? lng ?? 0;
@@ -46,6 +49,9 @@ export class Driver {
       this.id = _driverIdCounter++;
       this.firstName = parts[0] || 'Driver';
       this.lastName = parts.slice(1).join(' ') || '';
+      this.age = 0;
+      this.gender = '';
+      this.experience = 0;
       this.color = color || '#39c';
       this.lat = lat || 0;
       this.lng = lng || 0;


### PR DESCRIPTION
## Summary
- replace add driver option with hire driver panel listing candidate details
- extend Driver model with age, gender and experience
- add Game logic to generate and hire drivers from candidate pool
- place close button at top-right and source candidates from driver profile file

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b1392766d883328ec5cf9c0069a3c0