### PR TITLE
Add startup menu for company setup and HQ marker

### DIFF
--- a/assets/css/styles.css
+++ b/assets/css/styles.css
@@ -23,6 +23,7 @@ select, input[type="number"], input[type="text"]{width:100%; padding:8px; border
 .pill{display:inline-block; padding:2px 8px; border-radius:999px; background:#19303b; border:1px solid #27414f; font-size:12px;}
 .legend{position:absolute; right:12px; top:12px; z-index:550; background:#0f1418; border:1px solid #2d3943; border-radius:10px; padding:8px 10px; display:flex; gap:10px; align-items:center;}
 .legend .dot{width:10px; height:10px; border-radius:50%; display:inline-block; margin-right:6px;}
+.hq-icon{width:12px; height:12px; background:red; border:2px solid #fff;}
 .note{opacity:.8; font-size:12px;}
 .row{display:flex; align-items:center; gap:8px; flex-wrap:wrap;}
 .drawbar{position:absolute; left:12px; bottom:70px; z-index:650; background:#0f1418; border:1px solid #2d3943; border-radius:10px; padding:8px; display:flex; gap:8px; align-items:center; flex-wrap:wrap;}

--- a/index.html
+++ b/index.html
@@ -14,6 +14,24 @@
 
     <div class="legend" id="legend"></div>
 
+    <!-- Start Menu -->
+    <dialog id="dlgStart" class="modal">
+      <div class="form">
+        <h3>Start Company</h3>
+        <div class="grid" style="gap:8px;">
+          <label>Company Name
+            <input id="txtCompanyName" type="text" />
+          </label>
+          <label>Headquarters
+            <select id="selHQ"></select>
+          </label>
+        </div>
+        <div class="row" style="margin-top:8px;">
+          <button id="btnStartGame" class="btn">Start</button>
+        </div>
+      </div>
+    </dialog>
+
     <!-- Draw & Save controls -->
     <div class="drawbar">
       <span class="lbl">Manual Route for</span>

--- a/src/main.js
+++ b/src/main.js
@@ -5,4 +5,4 @@ window.UI = UI;
 window.Game = Game;
 
 UI.init();
-Game.init();
+UI.initStartMenu();

--- a/src/ui_game.js
+++ b/src/ui_game.js
@@ -67,6 +67,25 @@ overlay(sel) {
 
     this.refreshAll();
   },
+  initStartMenu(){
+    const dlg=document.getElementById('dlgStart');
+    if(!dlg){ Game.init(); return; }
+    const sel=dlg.querySelector('#selHQ');
+    if(sel) fillCitySelectGrouped(sel);
+    dlg.showModal();
+    const btn=dlg.querySelector('#btnStartGame');
+    if(btn){
+      btn.addEventListener('click',()=>{
+        const name=(dlg.querySelector('#txtCompanyName').value||'').trim()||'My Company';
+        const city=cityByName(sel.value);
+        Game.companyName=name;
+        Game.setHQ(city);
+        dlg.close();
+        Game.init();
+        UI.refreshCompany();
+      });
+    }
+  },
   initOverridesUI(){
     const selO=document.getElementById('ovrOrigin'), selD=document.getElementById('ovrDest');
     const btnToggle=document.getElementById('btnToggleCompleted');
@@ -185,6 +204,8 @@ overlay(sel) {
   refreshCompany(){
     const panel = document.getElementById('panelCompany');
     if (!panel) return;
+    const hdr=panel.querySelector('header > div:first-child');
+    if(hdr) hdr.textContent=Game.companyName||'Company';
     const content = panel.querySelector('.content');
     if (!content) return;
 
@@ -660,6 +681,9 @@ export const Game = {
   loads: [],
   cashFlow: [],
   loans: [],
+  companyName: '',
+  hqCity: null,
+  hqMarker: null,
   // --- Simulation Time (starts Jan 1, 2020) ---
   simEpoch: new Date(2020, 0, 1, 0, 0, 0), // Jan 1, 2020
   _simElapsedMs: 0,
@@ -683,6 +707,13 @@ export const Game = {
     this.cashFlow.push({time:this.getSimNow().getTime(), amount, desc});
     UI.refreshCompany();
     UI.refreshBank();
+  },
+
+  setHQ(city){
+    this.hqCity = city;
+    if(this.hqMarker){ this.hqMarker.remove(); }
+    const icon = L.divIcon({ className: 'hq-icon', iconSize:[12,12] });
+    this.hqMarker = L.marker([city.lat, city.lng], { icon }).addTo(map);
   },
 
   tickMs: 1000,


### PR DESCRIPTION
## Summary
- Add startup dialog to name company and choose HQ city from existing city list
- Draw red square HQ marker on map using selected city
- Store company info and show name in company panel

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68b3c4f4d9008332964d6d2494457571