### PR TITLE
Add startup company setup and HQ marker

### DIFF
--- a/assets/css/styles.css
+++ b/assets/css/styles.css
@@ -23,6 +23,7 @@ select, input[type="number"], input[type="text"]{width:100%; padding:8px; border
 .pill{display:inline-block; padding:2px 8px; border-radius:999px; background:#19303b; border:1px solid #27414f; font-size:12px;}
 .legend{position:absolute; right:12px; top:12px; z-index:550; background:#0f1418; border:1px solid #2d3943; border-radius:10px; padding:8px 10px; display:flex; gap:10px; align-items:center;}
 .legend .dot{width:10px; height:10px; border-radius:50%; display:inline-block; margin-right:6px;}
+.hq-marker{width:12px; height:12px; background:rgba(255,0,0,0.7); border:1px solid red;}
 .note{opacity:.8; font-size:12px;}
 .row{display:flex; align-items:center; gap:8px; flex-wrap:wrap;}
 .drawbar{position:absolute; left:12px; bottom:70px; z-index:650; background:#0f1418; border:1px solid #2d3943; border-radius:10px; padding:8px; display:flex; gap:8px; align-items:center; flex-wrap:wrap;}
@@ -345,4 +346,32 @@ bottom: 84px; z-index: 1200;}
   max-height: none !important;
   height: auto !important;
   overflow: visible !important;
+}
+
+/* Startup modal */
+#startupModal {
+  position: fixed;
+  top: 0;
+  left: 0;
+  width: 100%;
+  height: 100%;
+  background: rgba(0,0,0,0.8);
+  display: none;
+  align-items: center;
+  justify-content: center;
+  z-index: 1000;
+}
+#startupModal .startup-box {
+  background: #0f1418;
+  border: 1px solid #2d3943;
+  border-radius: 10px;
+  padding: 20px;
+  width: 300px;
+  max-width: 90vw;
+}
+#startupModal .field {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+  margin-bottom: 8px;
 }

--- a/index.html
+++ b/index.html
@@ -14,6 +14,22 @@
 
     <div class="legend" id="legend"></div>
 
+    <!-- Startup Modal -->
+    <div id="startupModal" class="startup-modal">
+      <div class="startup-box">
+        <h2>Start Company</h2>
+        <div class="field">
+          <label for="startupName">Company Name</label>
+          <input id="startupName" type="text" />
+        </div>
+        <div class="field">
+          <label for="startupCity">Headquarters</label>
+          <select id="startupCity"></select>
+        </div>
+        <button id="startupBegin" class="btn">Start</button>
+      </div>
+    </div>
+
     <!-- Draw & Save controls -->
     <div class="drawbar">
       <span class="lbl">Manual Route for</span>
@@ -34,7 +50,7 @@
     <!-- Company Panel -->
     <div class="panel" id="panelCompany">
       <header>
-        <div>Company</div>
+        <div id="companyPanelTitle">Company</div>
         <div class="close-x" data-close="#panelCompany">✕</div>
       </header>
       <div class="content">

--- a/src/ui_game.js
+++ b/src/ui_game.js
@@ -45,14 +45,31 @@ export const UI = {
   _hirePage: 0,
   _ensurePlus15Button(){ const hud=document.querySelector('#timeHud .clock')||document.getElementById('timeHud'); if(!hud) return; if(document.getElementById('btnPlus15')) return; const btn=document.createElement('button'); btn.id='btnPlus15'; btn.className='btn'; btn.title='Advance 15 sim minutes'; btn.textContent='+15m'; btn.onclick=()=>{ Game.jump(15*60*1000); UI.updateTimeHUD(); }; const b4=hud.querySelector('button[onclick*="Game.resume(4)"]'); if(b4&&b4.parentNode) b4.parentNode.insertBefore(btn, b4.nextSibling); else hud.appendChild(btn); },
   show(sel){ document.querySelectorAll('.panel').forEach(p=>p.style.display='none'); const el=document.querySelector(sel); if (el) el.style.display='block'; if(sel==='#panelCompany'){ try{ const s=document.getElementById('txtDriverSearch'); if(s) s.value=''; UI._companyNeedsListRefresh=true; UI.refreshCompany(); }catch(e){} } if(sel==='#panelBank'){ try{ UI.refreshBank(); }catch(e){} } if(sel==='#panelMarket'){ try{ UI.renderMarket(); }catch(e){} } if(sel==='#panelEquipment'){ try{ UI.refreshEquipment(); }catch(e){} } if(sel==='#panelProperties'){ try{ UI.refreshProperties(); }catch(e){} } },
-overlay(sel) {
-  ['#panelEquipment', '#panelProperties'].forEach(p => {
-    const panel = document.querySelector(p);
-    if (panel) panel.style.display = (p === sel) ? 'block' : 'none';
-  });
-  if (sel === '#panelEquipment') { try { UI.refreshEquipment(); } catch (e) {} }
-  if (sel === '#panelProperties') { try { UI.refreshProperties(); } catch (e) {} }
-},
+  overlay(sel) {
+    ['#panelEquipment', '#panelProperties'].forEach(p => {
+      const panel = document.querySelector(p);
+      if (panel) panel.style.display = (p === sel) ? 'block' : 'none';
+    });
+    if (sel === '#panelEquipment') { try { UI.refreshEquipment(); } catch (e) {} }
+    if (sel === '#panelProperties') { try { UI.refreshProperties(); } catch (e) {} }
+  },
+  showStartup(){
+    const modal=document.getElementById('startupModal');
+    if(!modal) return;
+    modal.style.display='flex';
+    const sel=document.getElementById('startupCity');
+    if(sel) fillCitySelectGrouped(sel);
+    const btn=document.getElementById('startupBegin');
+    if(btn){
+      btn.onclick=()=>{
+        const name=(document.getElementById('startupName').value||'').trim();
+        const cityName=sel?sel.value:'';
+        if(!name){ alert('Enter company name'); return; }
+        Game.setCompanyInfo(name, cityName);
+        modal.style.display='none';
+      };
+    }
+  },
   init(){
     document.querySelectorAll('.close-x').forEach(x=>x.addEventListener('click', e=>{ const t=e.currentTarget.getAttribute('data-close'); if (t) document.querySelector(t).style.display='none'; }));
     ['panelCompany','panelMarket','panelBank','panelEquipment','panelProperties'].forEach(id=>makeDraggable(document.getElementById(id)));
@@ -188,12 +205,13 @@ overlay(sel) {
     const content = panel.querySelector('.content');
     if (!content) return;
 
-    if (!UI._companyWired){
-      const trucks = Game.equipment.filter(e=>e.type==='truck').length;
-      const props = Game.properties.length;
-      const overhead = trucks*Game.overheadPerTruck + props*Game.overheadPerProperty;
+    const trucks = Game.equipment.filter(e=>e.type==='truck').length;
+    const props = Game.properties.length;
+    const overhead = trucks*Game.overheadPerTruck + props*Game.overheadPerProperty;
 
+    if (!UI._companyWired){
       content.innerHTML = `
+        <div id="companyHQDisplay" class="small" style="margin-bottom:8px; display:none;"></div>
         <div class="grid cols-2 company-grid">
           <div>
             <div class="stat">
@@ -215,7 +233,7 @@ overlay(sel) {
             </div>
 
             <div id="driversList" class="drivers-list"></div>
-            
+
           </div>
           <div>
             <div id="driverProfile" class="driver-profile">
@@ -288,8 +306,17 @@ overlay(sel) {
       UI._companyWired = true; try{ UI._companyNeedsListRefresh=true; UI._companyRenderDriverList(); }catch(e){}
     }
 
-    const trucks=Game.equipment.filter(e=>e.type==='truck').length, props=Game.properties.length;
-    const overhead=trucks*Game.overheadPerTruck + props*Game.overheadPerProperty;
+    const titleEl = document.getElementById('companyPanelTitle');
+    if(titleEl) titleEl.textContent = Game.companyName || 'Company';
+    const hqEl = content.querySelector('#companyHQDisplay');
+    if(hqEl){
+      if(Game.hqCity){
+        hqEl.textContent = 'HQ: ' + Game.hqCity.name;
+        hqEl.style.display = 'block';
+      } else {
+        hqEl.style.display = 'none';
+      }
+    }
     const bankEl = document.getElementById('statBank'); if (bankEl) bankEl.textContent = '$' + Game.bank.toLocaleString();
     const ohEl = document.getElementById('statOverhead'); if (ohEl) ohEl.textContent = '$' + overhead.toLocaleString() + ' / day';
 
@@ -650,6 +677,9 @@ function makeDraggable(panel){
 }
 
 export const Game = {
+  companyName: '',
+  hqCity: null,
+  hqMarker: null,
   bank: 250000,
   overheadPerTruck: 50,
   overheadPerProperty: 200,
@@ -685,8 +715,38 @@ export const Game = {
     UI.refreshBank();
   },
 
+  loadCompanyInfo(){
+    try { return JSON.parse(localStorage.getItem('companyInfo')); } catch(_){ return null; }
+  },
+  setCompanyInfo(name, cityName){
+    this.companyName = name;
+    this.hqCity = cityByName(cityName);
+    try{ localStorage.setItem('companyInfo', JSON.stringify({name, cityName})); }catch(_){ }
+    this.renderHQ();
+    UI.refreshCompany();
+  },
+  renderHQ(){
+    if(this.hqMarker){ try{ map.removeLayer(this.hqMarker); }catch(e){} }
+    if(!this.hqCity) return;
+    const lat=this.hqCity.lat, lng=this.hqCity.lng;
+    const px=12;
+    this.hqMarker=L.marker([lat,lng],{
+      interactive:false,
+      icon:L.divIcon({className:'hq-marker', iconSize:[px,px], iconAnchor:[px/2,px/2]})
+    });
+    this.hqMarker.addTo(map);
+  },
+
   tickMs: 1000,
   init() {
+    const info=this.loadCompanyInfo();
+    if(info&&info.name&&info.cityName){
+      this.companyName=info.name;
+      this.hqCity=cityByName(info.cityName);
+      this.renderHQ();
+    } else {
+      UI.showStartup();
+    }
     this.generateHireDrivers();
     this.addDriver('Alice', cityByName('Chicago, IL'));
     this.addDriver('Ben',   cityByName('Dallas, TX'));


### PR DESCRIPTION
## Summary
- Display company name in Company panel header with HQ shown directly below
- Enlarge HQ marker on map
- Make HQ marker a constant pixel square so it stays visible across zoom levels
- Anchor HQ marker directly to the selected city so it remains aligned at all zoom levels

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b3c4f4d9008332964d6d2494457571