### PR TITLE
Add Dev Tools toggle

### DIFF
--- a/index.html
+++ b/index.html
@@ -31,7 +31,7 @@
     </div>
 
     <!-- Draw & Save controls -->
-    <div class="drawbar">
+    <div class="drawbar" style="display:none;">
       <span class="lbl">Manual Route for</span>
       <select id="ovrOrigin"></select>
       <span>→</span>
@@ -117,6 +117,7 @@
       <button onclick="UI.show('#panelCompany')">Company</button>
       <button onclick="UI.show('#panelMarket')">Market</button>
       <button onclick="UI.openLoadBoard()">Load Board</button>
+      <button id="btnDevTools" onclick="UI.toggleDevTools()">Show Dev Tools</button>
     </div>
   </div>
 

--- a/src/ui_game.js
+++ b/src/ui_game.js
@@ -70,6 +70,14 @@ export const UI = {
       };
     }
   },
+  toggleDevTools(){
+    const bar=document.querySelector('.drawbar');
+    if(!bar) return;
+    const hidden=bar.style.display==='none' || getComputedStyle(bar).display==='none';
+    bar.style.display=hidden?'flex':'none';
+    const btn=document.getElementById('btnDevTools');
+    if(btn) btn.textContent=hidden?'Hide Dev Tools':'Show Dev Tools';
+  },
   init(){
     document.querySelectorAll('.close-x').forEach(x=>x.addEventListener('click', e=>{ const t=e.currentTarget.getAttribute('data-close'); if (t) document.querySelector(t).style.display='none'; }));
     ['panelCompany','panelMarket','panelBank','panelEquipment','panelProperties'].forEach(id=>makeDraggable(document.getElementById(id)));


### PR DESCRIPTION
## Summary
- Add a new toolbar button to toggle visibility of route creation tools
- Hide route draw bar by default and allow toggling display
- Implement UI.toggleDevTools to update button label and show/hide drawbar

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68b3cff4de0c8332a6d7e3cb635ffda7