### PR TITLE
Add dev tools toggle for route creation tools

### DIFF
--- a/index.html
+++ b/index.html
@@ -31,7 +31,7 @@
     </div>
 
     <!-- Draw & Save controls -->
-    <div class="drawbar">
+    <div id="drawbar" class="drawbar" style="display:none;">
       <span class="lbl">Manual Route for</span>
       <select id="ovrOrigin"></select>
       <span>→</span>
@@ -114,6 +114,7 @@
     </div>
 
     <div class="toolbar">
+      <button id="btnDevTools">Show Dev Tools</button>
       <button onclick="UI.show('#panelCompany')">Company</button>
       <button onclick="UI.show('#panelMarket')">Market</button>
       <button onclick="UI.openLoadBoard()">Load Board</button>

--- a/src/main.js
+++ b/src/main.js
@@ -6,3 +6,13 @@ window.Game = Game;
 
 UI.init();
 Game.init();
+
+const devBtn=document.getElementById('btnDevTools');
+const drawbar=document.getElementById('drawbar');
+if(devBtn && drawbar){
+  devBtn.addEventListener('click',()=>{
+    const show=drawbar.style.display==='none';
+    drawbar.style.display=show?'flex':'none';
+    devBtn.textContent=show?'Hide Dev Tools':'Show Dev Tools';
+  });
+}


### PR DESCRIPTION
## Summary
- Hide route creation "drawbar" controls by default
- Add "Dev Tools" button to toggle route creation tools visibility
- Wire up toggle logic in main script

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68b3cff4de0c8332a6d7e3cb635ffda7