### PR TITLE
Add Dev Tools toggle

### DIFF
--- a/index.html
+++ b/index.html
@@ -31,7 +31,7 @@
     </div>
 
     <!-- Draw & Save controls -->
-    <div class="drawbar">
+    <div class="drawbar" style="display:none;">
       <span class="lbl">Manual Route for</span>
       <select id="ovrOrigin"></select>
       <span>→</span>
@@ -117,6 +117,7 @@
       <button onclick="UI.show('#panelCompany')">Company</button>
       <button onclick="UI.show('#panelMarket')">Market</button>
       <button onclick="UI.openLoadBoard()">Load Board</button>
+      <button id="btnDevTools" onclick="UI.toggleDevTools()">Show Dev Tools</button>
     </div>
   </div>
 

--- a/src/drawing.js
+++ b/src/drawing.js
@@ -7,6 +7,9 @@ export const drawControl = new L.Control.Draw({
   draw: { polyline: { shapeOptions: { color: '#00e5ff', weight: 4 } }, polygon:false, rectangle:false, circle:false, marker:false, circlemarker:false }
 });
 map.addControl(drawControl);
+if (drawControl && drawControl._container) {
+  drawControl._container.style.display = 'none';
+}
 
 export function clearNonOverrideDrawings(){ drawnItems.eachLayer(l => drawnItems.removeLayer(l)); }
 export function currentDrawnPolylineLatLngs(){ let latlngs=null; drawnItems.eachLayer(l => { if (l instanceof L.Polyline) latlngs = l.getLatLngs(); }); return latlngs; }

--- a/src/ui_game.js
+++ b/src/ui_game.js
@@ -70,6 +70,16 @@ export const UI = {
       };
     }
   },
+  toggleDevTools(){
+    const bar = document.querySelector('.drawbar');
+    const ctrl = drawControl && drawControl._container;
+    const hidden = bar ? (bar.style.display==='none' || getComputedStyle(bar).display==='none')
+                       : (ctrl ? (ctrl.style.display==='none' || getComputedStyle(ctrl).display==='none') : true);
+    if(bar) bar.style.display = hidden ? 'flex' : 'none';
+    if(ctrl) ctrl.style.display = hidden ? 'block' : 'none';
+    const btn = document.getElementById('btnDevTools');
+    if(btn) btn.textContent = hidden ? 'Hide Dev Tools' : 'Show Dev Tools';
+  },
   init(){
     document.querySelectorAll('.close-x').forEach(x=>x.addEventListener('click', e=>{ const t=e.currentTarget.getAttribute('data-close'); if (t) document.querySelector(t).style.display='none'; }));
     ['panelCompany','panelMarket','panelBank','panelEquipment','panelProperties'].forEach(id=>makeDraggable(document.getElementById(id)));


### PR DESCRIPTION
## Summary
- Add toolbar button to toggle route creation tools
- Hide draw bar and Leaflet draw toolbar by default and toggle both together
- Update UI.toggleDevTools to switch button label and show/hide dev tools

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b3cff4de0c8332a6d7e3cb635ffda7