### PR TITLE
feat: add pause menu with save and load

### DIFF
--- a/assets/css/styles.css
+++ b/assets/css/styles.css
@@ -375,3 +375,31 @@ bottom: 84px; z-index: 1200;}
   gap: 4px;
   margin-bottom: 8px;
 }
+
+/* Pause menu */
+#pauseMenu {
+  position: fixed;
+  top: 0;
+  left: 0;
+  width: 100%;
+  height: 100%;
+  background: rgba(0,0,0,0.8);
+  display: none;
+  align-items: center;
+  justify-content: center;
+  z-index: 1000;
+}
+#pauseMenu .pause-box {
+  background: #0f1418;
+  border: 1px solid #2d3943;
+  border-radius: 10px;
+  padding: 20px;
+  width: 200px;
+  max-width: 90vw;
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+}
+#pauseMenu .btn {
+  width: 100%;
+}

--- a/index.html
+++ b/index.html
@@ -119,6 +119,18 @@
       <button onclick="UI.openLoadBoard()">Load Board</button>
       <button id="btnDevTools" onclick="UI.toggleDevTools()">Show Dev Tools</button>
     </div>
+
+    <!-- Pause Menu -->
+    <div id="pauseMenu" class="pause-menu">
+      <div class="pause-box">
+        <h2>Paused</h2>
+        <button id="btnResume" class="btn">Resume</button>
+        <button id="btnSaveGame" class="btn">Save Game</button>
+        <button id="btnLoadGame" class="btn">Load Game</button>
+        <button id="btnNewGame" class="btn">Start New Game</button>
+        <input id="fileLoadGame" class="file-input" type="file" accept="application/json"/>
+      </div>
+    </div>
   </div>
 
   <script src="https://unpkg.com/leaflet@1.9.4/dist/leaflet.js"></script>


### PR DESCRIPTION
## Summary
- add spacebar pause menu with options to save, load, or start a new game
- enable saving game state to local storage and exporting/importing save files
- style new pause menu overlay

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b3d3804c108332aa6c5a8ff0f84544