### PR TITLE
feat: add pause menu and save system

### DIFF
--- a/assets/css/styles.css
+++ b/assets/css/styles.css
@@ -375,3 +375,7 @@ bottom: 84px; z-index: 1200;}
   gap: 4px;
   margin-bottom: 8px;
 }
+
+/* Pause menu */
+.pause-overlay{position:fixed;top:0;left:0;width:100%;height:100%;background:rgba(0,0,0,.7);display:none;align-items:center;justify-content:center;z-index:2000;}
+.pause-menu{background:#0f1418;border:1px solid #2d3943;border-radius:10px;padding:20px;display:flex;flex-direction:column;gap:10px;}

--- a/index.html
+++ b/index.html
@@ -119,6 +119,15 @@
       <button onclick="UI.openLoadBoard()">Load Board</button>
       <button id="btnDevTools" onclick="UI.toggleDevTools()">Show Dev Tools</button>
     </div>
+    <div id="pauseMenu" class="pause-overlay">
+      <div class="pause-menu">
+        <button id="pmSave" class="btn">Save Game</button>
+        <label for="pmLoadInput" class="btn">Load Game</label>
+        <input id="pmLoadInput" class="file-input" type="file" accept="application/json"/>
+        <button id="pmNew" class="btn">Start New Game</button>
+        <button id="pmResume" class="btn">Resume</button>
+      </div>
+    </div>
   </div>
 
   <script src="https://unpkg.com/leaflet@1.9.4/dist/leaflet.js"></script>

--- a/src/driver.js
+++ b/src/driver.js
@@ -12,7 +12,8 @@ export class Driver {
   constructor(arg1, lat, lng, color) {
     if (typeof arg1 === 'object' && arg1 !== null) {
       const d = arg1;
-      this.id = _driverIdCounter++;
+      this.id = (typeof d.id === 'number') ? d.id : _driverIdCounter++;
+      if (typeof d.id === 'number' && d.id >= _driverIdCounter) _driverIdCounter = d.id + 1;
       this.firstName = d.firstName || '';
       this.lastName = d.lastName || '';
       this.age = d.age || 0;
@@ -199,4 +200,8 @@ export class Driver {
       setTimeout(()=>{ try{ map.removeLayer(oldLine); }catch(e){} }, 4000);
     }
   }
+}
+
+export function setDriverIdCounter(n){
+  if (typeof n === 'number' && n > 0) _driverIdCounter = n;
 }


### PR DESCRIPTION
## Summary
- add spacebar-triggered pause menu with save/load/new game controls
- enable exporting and importing game state
- support driver ID persistence for reloading

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b3d3804c108332aa6c5a8ff0f84544