### PR TITLE
Add property purchase options with map markers

### DIFF
--- a/assets/css/styles.css
+++ b/assets/css/styles.css
@@ -24,6 +24,9 @@ select, input[type="number"], input[type="text"]{width:100%; padding:8px; border
 .legend{position:absolute; right:12px; top:12px; z-index:550; background:#0f1418; border:1px solid #2d3943; border-radius:10px; padding:8px 10px; display:flex; gap:10px; align-items:center;}
 .legend .dot{width:10px; height:10px; border-radius:50%; display:inline-block; margin-right:6px;}
 .hq-marker{width:12px; height:12px; background:rgba(255,0,0,0.7); border:1px solid red;}
+.prop-marker-small{width:12px; height:12px; background:purple; border:1px solid #800080;}
+.prop-marker-large{width:12px; height:12px; background:blue; border:1px solid #0000aa;}
+.prop-marker-warehouse{width:12px; height:12px; background:yellow; border:1px solid #999900;}
 .note{opacity:.8; font-size:12px;}
 .row{display:flex; align-items:center; gap:8px; flex-wrap:wrap;}
 .drawbar{position:absolute; left:12px; bottom:70px; z-index:650; background:#0f1418; border:1px solid #2d3943; border-radius:10px; padding:8px; display:flex; gap:8px; align-items:center; flex-wrap:wrap;}


### PR DESCRIPTION
## Summary
- Add small/large yard and warehouse purchase options with city selectors
- Track purchased properties and render colored markers on the map
- Style property markers for small yards (purple), large yards (blue), and warehouses (yellow)

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68b3d798a5308332b345a6d46a40df3e