### PR TITLE
Add OSRM-based highway polyline routing

### DIFF
--- a/src/osrmRouter.js
+++ b/src/osrmRouter.js
@@ -1,0 +1,37 @@
+/**
+ * Parse a response from the OSRM routing service into the
+ * internal representation used by the simulator.
+ * @param {object} data The JSON response from OSRM.
+ * @returns {{path: Array<{lat:number,lng:number}>, distanceMiles:number, durationMs:number}}
+ */
+export function parseOSRMRoute(data) {
+  if (!data || !Array.isArray(data.routes) || data.routes.length === 0) {
+    throw new Error('No routes found in OSRM response');
+  }
+  const route = data.routes[0];
+  if (!route.geometry || !Array.isArray(route.geometry.coordinates)) {
+    throw new Error('Missing geometry in OSRM response');
+  }
+  const path = route.geometry.coordinates.map(([lng, lat]) => ({ lat, lng }));
+  const distanceMiles = route.distance / 1609.34; // meters -> miles
+  const durationMs = route.duration * 1000; // seconds -> ms
+  return { path, distanceMiles, durationMs };
+}
+
+/**
+ * Fetch a driving route that follows major highways between two points
+ * using the public OSRM service. This function requires network access.
+ *
+ * @param {{lat:number,lng:number}} orig Origin point
+ * @param {{lat:number,lng:number}} dest Destination point
+ * @returns {Promise<{path:Array<{lat:number,lng:number}>, distanceMiles:number, durationMs:number}>}
+ */
+export async function routeHighways(orig, dest) {
+  const url = `https://router.project-osrm.org/route/v1/driving/${orig.lng},${orig.lat};${dest.lng},${dest.lat}?overview=full&geometries=geojson`;
+  const resp = await fetch(url);
+  if (!resp.ok) {
+    throw new Error(`OSRM request failed: ${resp.status}`);
+  }
+  const data = await resp.json();
+  return parseOSRMRoute(data);
+}

--- a/src/router.js
+++ b/src/router.js
@@ -1,6 +1,7 @@
 import { OverrideStore } from './store.js';
 import { graphRoute } from './graph.js';
 import { haversineMiles } from './utils.js';
+import { routeHighways } from './osrmRouter.js';
 
 export const Router = {
   async route(orig, dest) {
@@ -11,7 +12,11 @@ export const Router = {
       let dist=0; for(let i=1;i<path.length;i++) dist += haversineMiles(path[i-1], path[i]);
       return { path, distanceMiles: dist, durationMs: 0 };
     }
-    const r = graphRoute({lat:orig.lat,lng:orig.lng},{lat:dest.lat,lng:dest.lng});
-    return { path: r.path, distanceMiles: r.distanceMiles, durationMs: 0 };
+    try {
+      return await routeHighways({lat:orig.lat,lng:orig.lng},{lat:dest.lat,lng:dest.lng});
+    } catch (err) {
+      const r = graphRoute({lat:orig.lat,lng:orig.lng},{lat:dest.lat,lng:dest.lng});
+      return { path: r.path, distanceMiles: r.distanceMiles, durationMs: 0 };
+    }
   }
 };

--- a/test/osrmRouter.test.js
+++ b/test/osrmRouter.test.js
@@ -1,0 +1,30 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { parseOSRMRoute } from '../src/osrmRouter.js';
+
+// Sample OSRM-like response for a route from New York City to Chicago
+const sample = {
+  routes: [
+    {
+      distance: 1275000, // meters (~792 miles)
+      duration: 45000,   // seconds
+      geometry: {
+        type: 'LineString',
+        coordinates: [
+          [-74.0060, 40.7128],
+          [-75.0, 41.0],
+          [-81.0, 41.0],
+          [-87.6298, 41.8781]
+        ]
+      }
+    }
+  ]
+};
+
+test('parseOSRMRoute converts OSRM output into internal route representation', () => {
+  const result = parseOSRMRoute(sample);
+  assert.equal(result.path.length, 4);
+  assert.ok(Math.abs(result.distanceMiles - (1275000 / 1609.34)) < 0.001);
+  assert.equal(result.durationMs, 45000 * 1000);
+  assert.deepEqual(result.path[0], { lat: 40.7128, lng: -74.0060 });
+});


### PR DESCRIPTION
## Summary
- add OSRM-powered routing module to fetch highway polylines
- route through OSRM in Router with graph fallback
- test OSRM response parsing

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68b3db2367688332ac5346d81c3e33c1