### PR TITLE
feat: add map legend with layer toggles

### DIFF
--- a/assets/css/styles.css
+++ b/assets/css/styles.css
@@ -21,8 +21,13 @@ select, input[type="number"], input[type="text"]{width:100%; padding:8px; border
 .btn{display:inline-block; padding:8px 12px; border:1px solid #2d3943; background:#1b2832; color:#e9eef1; border-radius:8px; cursor:pointer;}
 .btn:hover{background:#223443;}
 .pill{display:inline-block; padding:2px 8px; border-radius:999px; background:#19303b; border:1px solid #27414f; font-size:12px;}
-.legend{position:absolute; right:12px; top:12px; z-index:550; background:#0f1418; border:1px solid #2d3943; border-radius:10px; padding:8px 10px; display:flex; gap:10px; align-items:center;}
-.legend .dot{width:10px; height:10px; border-radius:50%; display:inline-block; margin-right:6px;}
+.legend{position:absolute; right:12px; top:12px; z-index:550; background:#0f1418; border:1px solid #2d3943; border-radius:10px; padding:8px 10px; display:flex; flex-direction:column; gap:8px; align-items:flex-start; width:220px; max-height:80vh; overflow:hidden;}
+.legend label{display:flex; align-items:center; gap:6px; cursor:pointer;}
+.legend .legend-title{font-weight:600; font-size:14px; margin-bottom:2px;}
+.legend .legend-drivers{max-height:150px; overflow:auto; display:flex; flex-direction:column; gap:4px; margin-top:4px; width:100%;}
+.legend .legend-driver{display:flex; align-items:center; gap:6px; font-size:13px;}
+.legend .dot{width:10px; height:10px; border-radius:50%; display:inline-block;}
+.legend .legend-driver .dot{margin-right:4px;}
 .hq-marker{width:12px; height:12px; background:rgba(255,0,0,0.7); border:1px solid red;}
 .prop-marker-small{width:12px; height:12px; background:purple; border:1px solid #800080;}
 .prop-marker-large{width:12px; height:12px; background:blue; border:1px solid #0000aa;}


### PR DESCRIPTION
## Summary
- add interactive map legend with layer toggles and per-driver checkboxes
- style legend for vertical layout with scrollable driver list
- ensure HQ and property markers respect legend visibility settings

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b3e1a90ca083328982e00cefae179b