### PR TITLE
Add map legend with layer toggles and driver visibility controls

### DIFF
--- a/assets/css/styles.css
+++ b/assets/css/styles.css
@@ -21,8 +21,13 @@ select, input[type="number"], input[type="text"]{width:100%; padding:8px; border
 .btn{display:inline-block; padding:8px 12px; border:1px solid #2d3943; background:#1b2832; color:#e9eef1; border-radius:8px; cursor:pointer;}
 .btn:hover{background:#223443;}
 .pill{display:inline-block; padding:2px 8px; border-radius:999px; background:#19303b; border:1px solid #27414f; font-size:12px;}
-.legend{position:absolute; right:12px; top:12px; z-index:550; background:#0f1418; border:1px solid #2d3943; border-radius:10px; padding:8px 10px; display:flex; gap:10px; align-items:center;}
+.legend{position:absolute; right:12px; top:12px; z-index:550; background:#0f1418; border:1px solid #2d3943; border-radius:10px; padding:8px 10px; display:flex; flex-direction:column; gap:8px; max-height:90vh; overflow:auto;}
 .legend .dot{width:10px; height:10px; border-radius:50%; display:inline-block; margin-right:6px;}
+.legend-section{display:flex; flex-direction:column; gap:4px;}
+.legend-section label{display:flex; align-items:center; gap:6px; cursor:pointer;}
+.legend-title{font-weight:600;}
+.legend-drivers-list{max-height:120px; overflow-y:auto; border:1px solid #1e2a33; border-radius:6px; padding:4px; display:flex; flex-direction:column; gap:4px;}
+.legend-drivers-list label{display:flex; align-items:center; gap:6px;}
 .hq-marker{width:12px; height:12px; background:rgba(255,0,0,0.7); border:1px solid red;}
 .prop-marker-small{width:12px; height:12px; background:purple; border:1px solid #800080;}
 .prop-marker-large{width:12px; height:12px; background:blue; border:1px solid #0000aa;}

--- a/src/driver.js
+++ b/src/driver.js
@@ -30,6 +30,7 @@ export class Driver {
       this.marker = L.circleMarker([this.lat, this.lng], { radius:7, color:this.color, weight:2, fillColor:this.color, fillOpacity:0.7 });
       this.routeLine = null;
       this.path = null; this.cumMiles = null;
+      this.visible = true;
       // Simple HOS: last 7 days of on-duty hours (0-11)
       this.hos = Array.isArray(d.hos) ? d.hos.slice(0,7) : Array.from({length:7}, ()=>Math.floor(4 + Math.random()*7));
       this.hosSegments = [];
@@ -64,14 +65,17 @@ export class Driver {
       this.marker = L.circleMarker([this.lat, this.lng], { radius:7, color:this.color, weight:2, fillColor:this.color, fillOpacity:0.7 });
       this.routeLine = null;
       this.path = null; this.cumMiles = null;
+      this.visible = true;
       this.hos = Array.from({length:7}, ()=>Math.floor(4 + Math.random()*7));
       this.hosLog = [];
       this._hosLastStatus = null;
     }
   }
   get name(){ return (this.firstName + ' ' + this.lastName).trim(); }
-  render(){ this.marker.addTo(map); }
+  render(){ if(this.visible) this.marker.addTo(map); }
   setPosition(lat,lng){ this.lat=lat; this.lng=lng; this.marker.setLatLng([lat,lng]); }
+  showOnMap(){ this.visible=true; try{ this.marker.addTo(map); }catch(e){} if(this.routeLine) try{ this.routeLine.addTo(map); }catch(e){} }
+  hideFromMap(){ this.visible=false; try{ map.removeLayer(this.marker); }catch(e){} if(this.routeLine) try{ map.removeLayer(this.routeLine); }catch(e){} }
   startTripPolyline(path, loadId){
     this.status='On Trip';
     this.currentLoadId = loadId;
@@ -79,7 +83,7 @@ export class Driver {
     this.cumMiles = cumulativeMiles(path);
     if (this.routeLine){ try{ map.removeLayer(this.routeLine);}catch(e){} }
     this.routeLine = L.polyline(path, { color:this.color, weight:3, opacity:0.9 });
-    this.routeLine.addTo(map);
+    if(this.visible) this.routeLine.addTo(map);
   }
   /** Called every tick to move marker/advance along path */
   tick(now, load){

--- a/src/ui_game.js
+++ b/src/ui_game.js
@@ -43,6 +43,7 @@ const TrailerPriceRanges = {
 export const UI = {
   _hosDayOffset: 0,
   _hirePage: 0,
+  legend:{ showHQ:true, showProperties:true, showManual:true },
   _ensurePlus15Button(){ const hud=document.querySelector('#timeHud .clock')||document.getElementById('timeHud'); if(!hud) return; if(document.getElementById('btnPlus15')) return; const btn=document.createElement('button'); btn.id='btnPlus15'; btn.className='btn'; btn.title='Advance 15 sim minutes'; btn.textContent='+15m'; btn.onclick=()=>{ Game.jump(15*60*1000); UI.updateTimeHUD(); }; const b4=hud.querySelector('button[onclick*="Game.resume(4)"]'); if(b4&&b4.parentNode) b4.parentNode.insertBefore(btn, b4.nextSibling); else hud.appendChild(btn); },
   show(sel){ document.querySelectorAll('.panel').forEach(p=>p.style.display='none'); const el=document.querySelector(sel); if (el) el.style.display='block'; if(sel==='#panelCompany'){ try{ const s=document.getElementById('txtDriverSearch'); if(s) s.value=''; UI._companyNeedsListRefresh=true; UI.refreshCompany(); }catch(e){} } if(sel==='#panelBank'){ try{ UI.refreshBank(); }catch(e){} } if(sel==='#panelMarket'){ try{ UI.renderMarket(); }catch(e){} } if(sel==='#panelEquipment'){ try{ UI.refreshEquipment(); }catch(e){} } if(sel==='#panelProperties'){ try{ UI.refreshProperties(); }catch(e){} } },
   overlay(sel) {
@@ -732,8 +733,36 @@ export const UI = {
   },
   refreshTablesLive(){ try{ UI.updateCompanyLive && UI.updateCompanyLive(); }catch(e){} try{ this.refreshDispatch(); }catch(e){} },
   updateLegend(){
-    const el=document.getElementById('legend'); el.innerHTML='<div class="note">Drivers</div>';
-    for (const d of Game.drivers){ const span=document.createElement('span'); span.innerHTML=`<span class="dot" style="background:${d.color}"></span>${d.name}`; el.appendChild(span); }
+    const el=document.getElementById('legend');
+    if(!el) return;
+    el.innerHTML='';
+    const layers=document.createElement('div');
+    layers.className='legend-section';
+    layers.innerHTML=`<div class="legend-title">Layers</div>
+      <label><input type="checkbox" id="lg-hq" ${UI.legend.showHQ?'checked':''}>HQ</label>
+      <label><input type="checkbox" id="lg-props" ${UI.legend.showProperties?'checked':''}>Properties</label>
+      <label><input type="checkbox" id="lg-manual" ${UI.legend.showManual?'checked':''}>Manual Routes</label>
+      <label><input type="checkbox" id="lg-completed" ${showCompletedRoutes?'checked':''}>Completed Routes</label>`;
+    el.appendChild(layers);
+    const dsec=document.createElement('div');
+    dsec.className='legend-section';
+    dsec.innerHTML='<div class="legend-title">Drivers</div><div id="legendDrivers" class="legend-drivers-list"></div>';
+    el.appendChild(dsec);
+    const list=dsec.querySelector('#legendDrivers');
+    for(const d of Game.drivers){
+      const item=document.createElement('label');
+      item.innerHTML=`<input type="checkbox" data-driver-id="${d.id}" ${d.visible!==false?'checked':''}><span class="dot" style="background:${d.color}"></span>${d.name}`;
+      list.appendChild(item);
+    }
+    const hqCb=el.querySelector('#lg-hq');
+    if(hqCb) hqCb.addEventListener('change',e=>{ UI.legend.showHQ=e.target.checked; if(Game.hqMarker){ e.target.checked?Game.hqMarker.addTo(map):map.removeLayer(Game.hqMarker); } });
+    const propCb=el.querySelector('#lg-props');
+    if(propCb) propCb.addEventListener('change',e=>{ UI.legend.showProperties=e.target.checked; for(const m of Game.propertyMarkers){ e.target.checked?m.addTo(map):map.removeLayer(m); } });
+    const manCb=el.querySelector('#lg-manual');
+    if(manCb) manCb.addEventListener('change',e=>{ UI.legend.showManual=e.target.checked; e.target.checked?drawnItems.addTo(map):map.removeLayer(drawnItems); });
+    const compCb=el.querySelector('#lg-completed');
+    if(compCb) compCb.addEventListener('change',e=>{ setShowCompletedRoutes(e.target.checked); });
+    list.querySelectorAll('input[data-driver-id]').forEach(cb=>cb.addEventListener('change',e=>{ const id=e.target.getAttribute('data-driver-id'); const d=Game.drivers.find(x=>String(x.id)===String(id)); if(d){ e.target.checked?d.showOnMap():d.hideFromMap(); } }));
   }
 };
 
@@ -820,7 +849,7 @@ export const Game = {
       interactive:false,
       icon:L.divIcon({className:'hq-marker', iconSize:[px,px], iconAnchor:[px/2,px/2]})
     });
-    this.hqMarker.addTo(map);
+    if(UI.legend.showHQ) this.hqMarker.addTo(map);
   },
 
   renderPropertyMarkers(){
@@ -845,7 +874,7 @@ export const Game = {
         interactive:false,
         icon:L.divIcon({className:cls,iconSize:[px,px],iconAnchor:[px/2,px/2]})
       });
-      marker.addTo(map);
+      if(UI.legend.showProperties) marker.addTo(map);
       this.propertyMarkers.push(marker);
     }
   },


### PR DESCRIPTION
## Summary
- replace top-right driver list with new map legend including layer toggles
- allow individual drivers to be shown or hidden and render scrollable driver menu
- add CSS styling for vertical legend layout and scrolling list

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68b3e1a90ca083328982e00cefae179b