### PR TITLE
Add map legend with layer toggles and driver visibility controls

### DIFF
--- a/assets/css/styles.css
+++ b/assets/css/styles.css
@@ -21,12 +21,17 @@ select, input[type="number"], input[type="text"]{width:100%; padding:8px; border
 .btn{display:inline-block; padding:8px 12px; border:1px solid #2d3943; background:#1b2832; color:#e9eef1; border-radius:8px; cursor:pointer;}
 .btn:hover{background:#223443;}
 .pill{display:inline-block; padding:2px 8px; border-radius:999px; background:#19303b; border:1px solid #27414f; font-size:12px;}
-.legend{position:absolute; right:12px; top:12px; z-index:550; background:#0f1418; border:1px solid #2d3943; border-radius:10px; padding:8px 10px; display:flex; gap:10px; align-items:center;}
+.legend{position:absolute; right:12px; top:12px; z-index:550; background:#0f1418; border:1px solid #2d3943; border-radius:10px; padding:8px 10px; display:flex; flex-direction:column; gap:8px; max-height:90vh; overflow:auto;}
 .legend .dot{width:10px; height:10px; border-radius:50%; display:inline-block; margin-right:6px;}
-.hq-marker{width:12px; height:12px; background:rgba(255,0,0,0.7); border:1px solid red;}
-.prop-marker-small{width:12px; height:12px; background:purple; border:1px solid #800080;}
-.prop-marker-large{width:12px; height:12px; background:blue; border:1px solid #0000aa;}
-.prop-marker-warehouse{width:12px; height:12px; background:yellow; border:1px solid #999900;}
+.legend-section{display:flex; flex-direction:column; gap:4px;}
+.legend-section label{display:flex; align-items:center; gap:6px; cursor:pointer;}
+.legend-title{font-weight:600;}
+.legend-drivers-list{max-height:120px; overflow-y:auto; border:1px solid #1e2a33; border-radius:6px; padding:4px; display:flex; flex-direction:column; gap:4px;}
+.legend-drivers-list label{display:flex; align-items:center; gap:6px;}
+.hq-marker{width:12px; height:12px; background:rgba(255,0,0,0.7); border:1px solid red; display:inline-block;}
+.prop-marker-small{width:12px; height:12px; background:purple; border:1px solid #800080; display:inline-block;}
+.prop-marker-large{width:12px; height:12px; background:blue; border:1px solid #0000aa; display:inline-block;}
+.prop-marker-warehouse{width:12px; height:12px; background:yellow; border:1px solid #999900; display:inline-block;}
 .note{opacity:.8; font-size:12px;}
 .row{display:flex; align-items:center; gap:8px; flex-wrap:wrap;}
 .drawbar{position:absolute; left:12px; bottom:70px; z-index:650; background:#0f1418; border:1px solid #2d3943; border-radius:10px; padding:8px; display:flex; gap:8px; align-items:center; flex-wrap:wrap;}

--- a/src/driver.js
+++ b/src/driver.js
@@ -30,6 +30,7 @@ export class Driver {
       this.marker = L.circleMarker([this.lat, this.lng], { radius:7, color:this.color, weight:2, fillColor:this.color, fillOpacity:0.7 });
       this.routeLine = null;
       this.path = null; this.cumMiles = null;
+      this.visible = true;
       // Simple HOS: last 7 days of on-duty hours (0-11)
       this.hos = Array.isArray(d.hos) ? d.hos.slice(0,7) : Array.from({length:7}, ()=>Math.floor(4 + Math.random()*7));
       this.hosSegments = [];
@@ -64,14 +65,17 @@ export class Driver {
       this.marker = L.circleMarker([this.lat, this.lng], { radius:7, color:this.color, weight:2, fillColor:this.color, fillOpacity:0.7 });
       this.routeLine = null;
       this.path = null; this.cumMiles = null;
+      this.visible = true;
       this.hos = Array.from({length:7}, ()=>Math.floor(4 + Math.random()*7));
       this.hosLog = [];
       this._hosLastStatus = null;
     }
   }
   get name(){ return (this.firstName + ' ' + this.lastName).trim(); }
-  render(){ this.marker.addTo(map); }
+  render(){ if(this.visible) this.marker.addTo(map); }
   setPosition(lat,lng){ this.lat=lat; this.lng=lng; this.marker.setLatLng([lat,lng]); }
+  showOnMap(){ this.visible=true; try{ this.marker.addTo(map); }catch(e){} if(this.routeLine) try{ this.routeLine.addTo(map); }catch(e){} }
+  hideFromMap(){ this.visible=false; try{ map.removeLayer(this.marker); }catch(e){} if(this.routeLine) try{ map.removeLayer(this.routeLine); }catch(e){} }
   startTripPolyline(path, loadId){
     this.status='On Trip';
     this.currentLoadId = loadId;
@@ -79,7 +83,7 @@ export class Driver {
     this.cumMiles = cumulativeMiles(path);
     if (this.routeLine){ try{ map.removeLayer(this.routeLine);}catch(e){} }
     this.routeLine = L.polyline(path, { color:this.color, weight:3, opacity:0.9 });
-    this.routeLine.addTo(map);
+    if(this.visible) this.routeLine.addTo(map);
   }
   /** Called every tick to move marker/advance along path */
   tick(now, load){


### PR DESCRIPTION
## Summary
- refine legend to show per-category property toggles with icons
- drop manual and completed route toggles; keep HQ toggle with icon
- manage property markers by category to support individual visibility

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b3e1a90ca083328982e00cefae179b