### PR TITLE
Add GUI tool for downloading US truck stop locations

### DIFF
--- a/truck_stop_locator/README.md
+++ b/truck_stop_locator/README.md
@@ -1,0 +1,16 @@
+# Truck Stop Locator
+
+This standalone Python tool fetches locations of major US truck stop chains (Love's, Flying J, Pilot, TA, and Petro) within the contiguous United States and saves them to `truck_stops.json`.
+
+## Requirements
+- Python 3 with Tkinter support
+- Internet access for querying the Overpass API
+
+## Usage
+Run the tool with:
+
+```bash
+python main.py
+```
+
+Click **Fetch Truck Stops** to query OpenStreetMap data and generate the JSON file. The results will be saved beside the script.

--- a/truck_stop_locator/main.py
+++ b/truck_stop_locator/main.py
@@ -1,0 +1,58 @@
+import json
+import os
+from urllib import request, parse
+import tkinter as tk
+from tkinter import messagebox
+
+def fetch_truck_stops():
+    """Fetch truck stop locations and save to a JSON file."""
+    overpass_url = "https://overpass-api.de/api/interpreter"
+    query = """
+    [out:json][timeout:50];
+    (
+      node["amenity"="fuel"]["brand"~"(?i)love's|flying j|pilot|travelcenters of america|petro|\\bta\\b"](24.5,-125,49.5,-66.5);
+      node["amenity"="fuel"]["name"~"(?i)love's|flying j|pilot|travelcenters of america|petro|\\bta\\b"](24.5,-125,49.5,-66.5);
+      way["amenity"="fuel"]["brand"~"(?i)love's|flying j|pilot|travelcenters of america|petro|\\bta\\b"](24.5,-125,49.5,-66.5);
+      way["amenity"="fuel"]["name"~"(?i)love's|flying j|pilot|travelcenters of america|petro|\\bta\\b"](24.5,-125,49.5,-66.5);
+    );
+    out center;
+    """
+    data = parse.urlencode({'data': query}).encode('utf-8')
+    try:
+        with request.urlopen(overpass_url, data=data) as response:
+            result = json.loads(response.read())
+    except Exception as exc:
+        messagebox.showerror("Error", f"Failed to fetch data: {exc}")
+        return
+
+    stops = []
+    for element in result.get('elements', []):
+        lat = element.get('lat') or element.get('center', {}).get('lat')
+        lon = element.get('lon') or element.get('center', {}).get('lon')
+        tags = element.get('tags', {})
+        name = tags.get('name') or tags.get('brand', 'Unknown')
+        if lat is None or lon is None:
+            continue
+        stops.append({'name': name, 'lat': lat, 'lon': lon})
+
+    output_path = os.path.join(os.path.dirname(__file__), 'truck_stops.json')
+    with open(output_path, 'w', encoding='utf-8') as f:
+        json.dump(stops, f, indent=2)
+
+    messagebox.showinfo("Complete", f"Saved {len(stops)} truck stops to {output_path}")
+
+
+def main():
+    window = tk.Tk()
+    window.title("Truck Stop Locator")
+
+    label = tk.Label(window, text="Fetch US Truck Stops", font=("Arial", 14))
+    label.pack(padx=20, pady=10)
+
+    fetch_button = tk.Button(window, text="Fetch Truck Stops", command=fetch_truck_stops)
+    fetch_button.pack(padx=20, pady=10)
+
+    window.mainloop()
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- add standalone Python GUI that queries Overpass API for major truck stop chains and writes locations to JSON
- document usage and requirements for the new tool

## Testing
- `python -m py_compile truck_stop_locator/main.py`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68b3f2821bd4833294ed5bfef0e2d9c4