### PR TITLE
Add truck stop markers and legend toggle

### DIFF
--- a/assets/css/styles.css
+++ b/assets/css/styles.css
@@ -32,6 +32,7 @@ select, input[type="number"], input[type="text"]{width:100%; padding:8px; border
 .prop-marker-small{width:12px; height:12px; background:purple; border:1px solid #800080; display:inline-block;}
 .prop-marker-large{width:12px; height:12px; background:blue; border:1px solid #0000aa; display:inline-block;}
 .prop-marker-warehouse{width:12px; height:12px; background:yellow; border:1px solid #999900; display:inline-block;}
+.truck-stop-marker{width:8px; height:8px; background:orange; border:1px solid #cc8400; display:inline-block;}
 .note{opacity:.8; font-size:12px;}
 .row{display:flex; align-items:center; gap:8px; flex-wrap:wrap;}
 .drawbar{position:absolute; left:12px; bottom:70px; z-index:650; background:#0f1418; border:1px solid #2d3943; border-radius:10px; padding:8px; display:flex; gap:8px; align-items:center; flex-wrap:wrap;}

--- a/src/ui_game.js
+++ b/src/ui_game.js
@@ -43,7 +43,7 @@ const TrailerPriceRanges = {
 export const UI = {
   _hosDayOffset: 0,
   _hirePage: 0,
-  legend:{ showHQ:true, showSmallYards:true, showLargeYards:true, showWarehouses:true },
+  legend:{ showHQ:true, showSmallYards:true, showLargeYards:true, showWarehouses:true, showTruckStops:true },
   _ensurePlus15Button(){ const hud=document.querySelector('#timeHud .clock')||document.getElementById('timeHud'); if(!hud) return; if(document.getElementById('btnPlus15')) return; const btn=document.createElement('button'); btn.id='btnPlus15'; btn.className='btn'; btn.title='Advance 15 sim minutes'; btn.textContent='+15m'; btn.onclick=()=>{ Game.jump(15*60*1000); UI.updateTimeHUD(); }; const b4=hud.querySelector('button[onclick*="Game.resume(4)"]'); if(b4&&b4.parentNode) b4.parentNode.insertBefore(btn, b4.nextSibling); else hud.appendChild(btn); },
   show(sel){ document.querySelectorAll('.panel').forEach(p=>p.style.display='none'); const el=document.querySelector(sel); if (el) el.style.display='block'; if(sel==='#panelCompany'){ try{ const s=document.getElementById('txtDriverSearch'); if(s) s.value=''; UI._companyNeedsListRefresh=true; UI.refreshCompany(); }catch(e){} } if(sel==='#panelBank'){ try{ UI.refreshBank(); }catch(e){} } if(sel==='#panelMarket'){ try{ UI.renderMarket(); }catch(e){} } if(sel==='#panelEquipment'){ try{ UI.refreshEquipment(); }catch(e){} } if(sel==='#panelProperties'){ try{ UI.refreshProperties(); }catch(e){} } },
   overlay(sel) {
@@ -761,7 +761,8 @@ export const UI = {
       <label><input type="checkbox" id="lg-hq" ${UI.legend.showHQ?'checked':''}><span class="hq-marker"></span>HQ</label>
       <label><input type="checkbox" id="lg-prop-small" ${UI.legend.showSmallYards?'checked':''}><span class="prop-marker-small"></span>Small Yards</label>
       <label><input type="checkbox" id="lg-prop-large" ${UI.legend.showLargeYards?'checked':''}><span class="prop-marker-large"></span>Large Yards</label>
-      <label><input type="checkbox" id="lg-prop-warehouse" ${UI.legend.showWarehouses?'checked':''}><span class="prop-marker-warehouse"></span>Warehouses</label>`;
+      <label><input type="checkbox" id="lg-prop-warehouse" ${UI.legend.showWarehouses?'checked':''}><span class="prop-marker-warehouse"></span>Warehouses</label>
+      <label><input type="checkbox" id="lg-truck-stops" ${UI.legend.showTruckStops?'checked':''}><span class="truck-stop-marker"></span>Truck Stops</label>`;
     el.appendChild(layers);
     const dsec=document.createElement('div');
     dsec.className='legend-section';
@@ -781,6 +782,8 @@ export const UI = {
     if(largeCb) largeCb.addEventListener('change',e=>{ UI.legend.showLargeYards=e.target.checked; for(const m of Game.propertyMarkers.large){ e.target.checked?m.addTo(map):map.removeLayer(m); } });
     const whCb=el.querySelector('#lg-prop-warehouse');
     if(whCb) whCb.addEventListener('change',e=>{ UI.legend.showWarehouses=e.target.checked; for(const m of Game.propertyMarkers.warehouse){ e.target.checked?m.addTo(map):map.removeLayer(m); } });
+    const tsCb=el.querySelector('#lg-truck-stops');
+    if(tsCb) tsCb.addEventListener('change',e=>{ UI.legend.showTruckStops=e.target.checked; for(const m of Game.truckStopMarkers){ e.target.checked?m.addTo(map):map.removeLayer(m); } });
     list.querySelectorAll('input[data-driver-id]').forEach(cb=>cb.addEventListener('change',e=>{ const id=e.target.getAttribute('data-driver-id'); const d=Game.drivers.find(x=>String(x.id)===String(id)); if(d){ e.target.checked?d.showOnMap():d.hideFromMap(); } }));
   }
 };
@@ -820,6 +823,8 @@ export const Game = {
   equipment: [],
   properties: [],
   propertyMarkers: { small:[], large:[], warehouse:[] },
+  truckStops: [],
+  truckStopMarkers: [],
   loads: [],
   cashFlow: [],
   loans: [],
@@ -895,6 +900,25 @@ export const Game = {
       });
       if(show) marker.addTo(map);
       arr.push(marker);
+    }
+  },
+
+  renderTruckStopMarkers(){
+    for(const m of this.truckStopMarkers){
+      try{ map.removeLayer(m); }catch(e){}
+    }
+    this.truckStopMarkers=[];
+    if(!Array.isArray(this.truckStops)) return;
+    const px=8;
+    for(const ts of this.truckStops){
+      const [lat,lng]=ts.coordinates||[];
+      if(lat==null||lng==null) continue;
+      const marker=L.marker([lat,lng],{
+        interactive:false,
+        icon:L.divIcon({className:'truck-stop-marker',iconSize:[px,px],iconAnchor:[px/2,px/2]})
+      });
+      if(UI.legend.showTruckStops) marker.addTo(map);
+      this.truckStopMarkers.push(marker);
     }
   },
 
@@ -1017,6 +1041,10 @@ export const Game = {
     this.addDriver('Alice', cityByName('Chicago, IL'));
     this.addDriver('Ben',   cityByName('Dallas, TX'));
     this.addDriver('Cara',  cityByName('Atlanta, GA'));
+    fetch('./truck_stops.json')
+      .then(r=>r.json())
+      .then(data=>{ this.truckStops=data; this.renderTruckStopMarkers(); })
+      .catch(()=>{});
     UI.refreshAll();
     if (this.loop) clearInterval(this.loop); this.loop = setInterval(()=>this.update(), this.tickMs);
     if (this.overheadLoop) clearInterval(this.overheadLoop); this.overheadLoop = setInterval(()=>this.applyOverhead(), 60000);


### PR DESCRIPTION
## Summary
- Display truck stop locations from `truck_stops.json` on the map with dedicated markers
- Introduce Truck Stops toggle in the legend to show or hide these markers
- Style truck stop markers with a distinct icon

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68b3fafc48548332bbfdca5059148098