### PR TITLE
Fix HOS break timing and daily totals

### DIFF
--- a/src/driver.js
+++ b/src/driver.js
@@ -43,6 +43,10 @@ export class Driver {
       this._hosLastTickMs = null;
       this.hosLog = [];
       this._hosLastStatus = null;
+      this.hosOnDutyToday = d.hosOnDutyToday || 0;
+      this._hosLastDayStr = d._hosLastDayStr || null;
+      this.currentBreak = d.currentBreak || null;
+      this._nextBreakTarget = d._nextBreakTarget || null;
     } else {
       // Backward compatibility (old: name, lat, lng, color)
       const name = String(arg1 || '').trim() || 'Driver';
@@ -69,6 +73,10 @@ export class Driver {
       this.hos = Array.from({length:7}, ()=>Math.floor(4 + Math.random()*7));
       this.hosLog = [];
       this._hosLastStatus = null;
+      this.hosOnDutyToday = 0;
+      this._hosLastDayStr = null;
+      this.currentBreak = null;
+      this._nextBreakTarget = null;
     }
   }
   get name(){ return (this.firstName + ' ' + this.lastName).trim(); }
@@ -85,6 +93,12 @@ export class Driver {
     this.routeLine = L.polyline(path, { color:this.color, weight:3, opacity:0.9 });
     if(this.visible) this.routeLine.addTo(map);
   }
+  startBreak(type,durationMs,nowMs,stop,pauseBase=0){
+    this.currentBreak={ type, startMs:nowMs, endMs:nowMs+durationMs, location:stop, pauseBase };
+    if(stop) this.setPosition(stop.lat, stop.lng);
+    this.status='SB';
+  }
+  endBreak(){ this.currentBreak=null; this.status='On Trip'; }
   /** Called every tick to move marker/advance along path */
   tick(now, load){
     if (!this.path || !this.cumMiles) return;
@@ -96,10 +110,10 @@ export class Driver {
     this.setPosition(p.lat, p.lng);
   }
   _hosStatus(){
-    if (this.currentLoadId) return 'D';
     const s = this.status || 'Idle';
     if (s === 'SB' || s === 'Sleeper') return 'SB';
     if (s === 'OFF' || s === 'Off Duty') return 'OFF';
+    if (this.currentLoadId) return 'D';
     return 'OFF';
   }
   _appendHosSegment(status, startHour, endHour){
@@ -117,38 +131,70 @@ export class Driver {
     for (let t=this._hosLastTickMs+stepMs; t<=nowMs; t+=stepMs){
       const st = this._hosStatus();
       const dt = new Date(t);
+      const dayStr = dt.toDateString();
+      if (this._hosLastDayStr && this._hosLastDayStr !== dayStr){
+        this.hos.push(this.hosOnDutyToday);
+        if (this.hos.length > 7) this.hos.shift();
+        this.hosOnDutyToday = 0;
+      }
+      this._hosLastDayStr = dayStr;
       const hr = dt.getHours() + dt.getMinutes()/60;
       this._appendHosSegment(st, hr-0.25, hr);
       if (st==='OFF' || st==='SB'){
         this.hosOffStreak += 0.25;
-        this.hosDriveSinceLastBreak = Math.max(0, this.hosDriveSinceLastBreak - 0.25);
+        if (this.hosOffStreak >= 0.5){
+          this.hosDriveSinceLastBreak = 0;
+          this._nextBreakTarget = null;
+        }
         if (this.hosOffStreak >= 10){ this.hosDutyStartMs=null; this.hosDriveSinceReset=0; }
+        if (this.hosOffStreak >= 34){
+          this.hos = Array(7).fill(0);
+          this.hosOnDutyToday = 0;
+          this.hosDutyStartMs=null;
+          this.hosDriveSinceReset=0;
+          this.hosDriveSinceLastBreak=0;
+          this._nextBreakTarget = null;
+        }
       } else {
         this.hosOffStreak = 0;
         if (!this.hosDutyStartMs) this.hosDutyStartMs = t;
-        if (st==='D'){ this.hosDriveSinceReset += 0.25; this.hosDriveSinceLastBreak += 0.25; }
+        if (st==='D'){
+          this.hosDriveSinceReset += 0.25;
+          this.hosDriveSinceLastBreak += 0.25;
+          if (this._nextBreakTarget===null && this.hosDriveSinceLastBreak >=5){
+            this._nextBreakTarget = 5 + Math.random()*3;
+          }
+        }
+        this.hosOnDutyToday += 0.25;
       }
       this._hosLastTickMs = t;
     }
   }
   isDrivingLegal(nowMs){
     const dutyStart = this.hosDutyStartMs;
+    const weekly = this.hos.reduce((a,b)=>a+b,0) + this.hosOnDutyToday;
+    if (weekly >= 70){
+      return { ok:false, reason:'70-hour limit reached. Take a 34-hour reset.', type:'34h', durationMs:34*3600*1000 };
+    }
     const onDutyHrs = dutyStart ? Math.max(0, (nowMs - dutyStart)/3600000) : 0;
     if (this.hosDriveSinceReset >= 11){
-      return { ok:false, reason:'11-hour driving limit reached. Take a 10-hour break.' };
+      return { ok:false, reason:'11-hour driving limit reached. Take a 10-hour break.', type:'10h', durationMs:10*3600*1000 };
     }
     if (dutyStart && onDutyHrs >= 14){
-      return { ok:false, reason:'14-hour duty window expired. Take a 10-hour break.' };
+      return { ok:false, reason:'14-hour duty window expired. Take a 10-hour break.', type:'10h', durationMs:10*3600*1000 };
     }
-    if (this.hosDriveSinceLastBreak >= 8){
-      return { ok:false, reason:'30-minute break required after 8h driving.' };
+    const breakLimit = this._nextBreakTarget || 8;
+    if (this.hosDriveSinceLastBreak >= breakLimit){
+      this._nextBreakTarget = null;
+      return { ok:false, reason:'30-minute break required.', type:'30m', durationMs:30*60*1000 };
     }
     return { ok:true };
   }
 
   _currentHosStatus(){
-    if (this.currentLoadId || this.status === 'On Trip') return 'D';
     if (this.status === 'SB' || this.status === 'Sleeper') return 'SB';
+    if (this.status === 'OFF' || this.status === 'Off Duty') return 'OFF';
+    if (this.currentLoadId || this.status === 'On Trip') return 'D';
     if (this.status === 'On Duty') return 'ON';
     return 'OFF';
   }
@@ -167,18 +213,41 @@ export class Driver {
     }
   }
 
-  getHosSegments24(nowMs){
+  /**
+   * Compute HOS segments for a 24 h window.  `nowMs` is the current
+   * simulation time.  `offsetMs` (optional) selects a prior day by shifting
+   * back in 24 h increments.  The returned segments are clipped so that the
+   * final segment ends at either the current time (for today) or at the end of
+   * the requested day (for past days).  This keeps the graph from assuming the
+   * driver will remain in the same status until midnight, which previously
+   * caused the drive line to jump to 23:59 when a load was assigned.
+   */
+  getHosSegments24(nowMs, offsetMs=0){
     const DAY_MS = 24*3600*1000;
-    const startMs = Math.max(0, nowMs - DAY_MS);
+    const targetMs = nowMs - offsetMs; // a time within the day we want to draw
+    const dt = new Date(targetMs);
+    dt.setHours(0,0,0,0);
+    const startMs = dt.getTime();
+    const endMs = startMs + DAY_MS;
+    // If looking at today, clip at the current time, otherwise show full day
+    const limitMs = offsetMs ? endMs : Math.min(nowMs, endMs);
+
     const evs = [];
     if (!this.hosLog.length){
-      return [{ start: 24-0.25, end: 24, status: 'OFF' }];
+      const endH = (limitMs - startMs) / 3600000;
+      return [{ start: 0, end: endH, status: 'OFF' }];
     }
-    let statusAtStart = this.hosLog[0].status;
-    for (const ev of this.hosLog){ if (ev.tMs <= startMs) statusAtStart = ev.status; else break; }
+
+    let statusAtStart = 'OFF';
+    for (const ev of this.hosLog){
+      if (ev.tMs <= startMs) statusAtStart = ev.status; else break;
+    }
     evs.push({ tMs: startMs, status: statusAtStart });
-    for (const ev of this.hosLog){ if (ev.tMs > startMs && ev.tMs < nowMs) evs.push({ tMs: ev.tMs, status: ev.status }); }
-    evs.push({ tMs: nowMs, status: evs.length ? evs[evs.length-1].status : statusAtStart });
+    for (const ev of this.hosLog){
+      if (ev.tMs > startMs && ev.tMs < limitMs) evs.push({ tMs: ev.tMs, status: ev.status });
+    }
+    evs.push({ tMs: limitMs, status: evs.length ? evs[evs.length-1].status : statusAtStart });
+
     const segs = [];
     for (let i=0;i<evs.length-1;i++){
       const a = evs[i], b = evs[i+1];

--- a/src/ui_game.js
+++ b/src/ui_game.js
@@ -1,7 +1,7 @@
 import { Colors } from './colors.js';
 import { Driver } from './driver.js';
 import { Router } from './router.js';
-import { fmtETA } from './utils.js';
+import { fmtETA, haversineMiles } from './utils.js';
 import { cityByName, CityGroups } from './data/cities.js';
 import { DriverProfiles } from './data/driver_profiles.js';
 import { drawnItems, drawControl, clearNonOverrideDrawings, currentDrawnPolylineLatLngs, showCompletedRoutes, completedRoutesGroup, showOverridePolyline, refreshCompletedRoutes, setShowCompletedRoutes } from './drawing.js';
@@ -572,7 +572,7 @@ export const UI = {
     ctx.clearRect(0,0,canvas.width,canvas.height);
 
     // Layout
-    const padding = { l: 40, r: 10, t: 10, b: 24 };
+    const padding = { l: 40, r: 60, t: 10, b: 24 };
     const W = canvas.width - padding.l - padding.r;
     const H = canvas.height - padding.t - padding.b;
 
@@ -622,15 +622,33 @@ export const UI = {
 
     // Data
     const offsetMs = (UI._hosDayOffset || 0) * 24 * 3600 * 1000;
-    let segs = (d.getHosSegments24 ? d.getHosSegments24(Game.getSimNow().getTime() - offsetMs) : []);
+    let segs = (d.getHosSegments24 ? d.getHosSegments24(Game.getSimNow().getTime(), offsetMs) : []);
     if (!segs.length) segs = UI._getHosSegments(d);
     if (!segs.length){
       ctx.fillStyle = '#888';
       ctx.textAlign = 'left';
       ctx.textBaseline = 'top';
       ctx.fillText('No HOS yet', padding.l, padding.t);
+      // Ensure totals area is cleared
+      ctx.fillStyle = '#fff';
+      ctx.textAlign = 'left';
+      ctx.textBaseline = 'middle';
+      rows.forEach((_, i)=>{
+        const y = padding.t + i*rowH + rowH/2;
+        ctx.clearRect(padding.l + W + 2, y - rowH/2, padding.r - 4, rowH);
+        ctx.fillText('00:00', padding.l + W + 4, y);
+      });
       ctx.restore();
       return;
+    }
+
+    // Totals per status
+    const totals = {OFF:0, SB:0, D:0, ON:0};
+    for (const seg of segs){
+      const st = seg.status || seg.s || 'OFF';
+      if (totals[st] !== undefined){
+        totals[st] += Math.max(0, (seg.end - seg.start));
+      }
     }
 
     // Draw segments as a continuous step graph, connecting status changes vertically
@@ -666,6 +684,21 @@ export const UI = {
       }
       ctx.stroke();
     }
+
+    // Totals text
+    const fmt = h => {
+      const m = Math.round(h * 60);
+      const hh = String(Math.floor(m / 60)).padStart(2,'0');
+      const mm = String(m % 60).padStart(2,'0');
+      return `${hh}:${mm}`;
+    };
+    ctx.textAlign = 'left';
+    ctx.textBaseline = 'middle';
+    ctx.fillStyle = '#fff';
+    rows.forEach((name, i)=>{
+      const y = padding.t + i*rowH + rowH/2;
+      ctx.fillText(fmt(totals[name]||0), padding.l + W + 4, y);
+    });
 
     ctx.restore();
   },
@@ -947,6 +980,31 @@ export const Game = {
     }
   },
 
+  findNearestStop(lat,lng){
+    const stops=[];
+    if(Array.isArray(this.truckStops)){
+      for(const ts of this.truckStops){
+        const [sLat,sLng]=ts.coordinates||[];
+        if(sLat==null||sLng==null) continue;
+        stops.push({name:ts.name, lat:sLat, lng:sLng});
+      }
+    }
+    if(Array.isArray(this.restAreas)){
+      for(const ra of this.restAreas){
+        const sLat=ra.latitude ?? ra.lat;
+        const sLng=ra.longitude ?? ra.lng;
+        if(sLat==null||sLng==null) continue;
+        stops.push({name:ra.name, lat:sLat, lng:sLng});
+      }
+    }
+    let best=null, bestDist=Infinity;
+    for(const s of stops){
+      const d=haversineMiles({lat,lng},{lat:s.lat,lng:s.lng});
+      if(d<bestDist){ best=s; bestDist=d; }
+    }
+    return best;
+  },
+
   _serializeDriver(d){
     return {
       firstName:d.firstName,lastName:d.lastName,age:d.age,gender:d.gender,experience:d.experience,
@@ -955,6 +1013,7 @@ export const Game = {
       path:d.path,cumMiles:d.cumMiles,hos:d.hos,hosSegments:d.hosSegments,hosDay:d.hosDay,
       hosDutyStartMs:d.hosDutyStartMs,hosDriveSinceReset:d.hosDriveSinceReset,
       hosDriveSinceLastBreak:d.hosDriveSinceLastBreak,hosOffStreak:d.hosOffStreak,hosLog:d.hosLog,
+      hosOnDutyToday:d.hosOnDutyToday,_hosLastDayStr:d._hosLastDayStr,currentBreak:d.currentBreak,
       _pendingMainLeg:d._pendingMainLeg
     };
   },
@@ -1244,11 +1303,28 @@ export const Game = {
 
   update(){ const realNow=performance.now(); if(!this.paused) this._simElapsedMs += (realNow - this._realLast)*this.speed; this._realLast = realNow; const now=this.getSimNow().getTime();
     for (const d of this.drivers) {
-      try{ d.syncHosLog(now); }catch(e){}
+      try{ d.syncHosLog(now); d.applyHosTick(now); }catch(e){}
+      const ld = this.loads.find(l => l.id === d.currentLoadId);
+      if (d.currentBreak) {
+        if (ld) ld.pauseMs = (d.currentBreak.pauseBase||0) + Math.min(now, d.currentBreak.endMs) - d.currentBreak.startMs;
+        if (now >= d.currentBreak.endMs) {
+          if (ld) ld.pauseMs = (d.currentBreak.pauseBase||0) + (d.currentBreak.endMs - d.currentBreak.startMs);
+          d.endBreak();
+        }
+        continue;
+      }
       if (d.status === 'On Trip') {
-        const ld = this.loads.find(l => l.id === d.currentLoadId);
         if (!ld) continue;
-        const t = (now - ld.startTime) / ld.etaMs;
+        const legal = d.isDrivingLegal(now);
+        if (!legal.ok) {
+          const stop = this.findNearestStop(d.lat, d.lng);
+          if (stop) {
+            ld.pauseMs = ld.pauseMs || 0;
+            d.startBreak(legal.type, legal.durationMs, now, stop, ld.pauseMs);
+          }
+          continue;
+        }
+        const t = (now - ld.startTime - (ld.pauseMs||0)) / ld.etaMs;
         if (t >= 1) {
           d.finishTrip(ld.end);
             if (ld.kind === 'Deadhead' && d._pendingMainLeg) {


### PR DESCRIPTION
## Summary
- Reset drive-since-break after 30 minutes off and schedule the next 30‑minute break between 5–8 driving hours
- Anchor HOS segment calculations to calendar days so daily totals only cover one day and past days remain fixed
- Clip HOS segments at the current time so new loads no longer render as 23:59 of driving and the per‑status totals stay accurate

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b406a94a9c8332b6e749063e22d2b4