### PR TITLE
Anchor HOS logs to calendar days

### DIFF
--- a/src/driver.js
+++ b/src/driver.js
@@ -167,18 +167,17 @@ export class Driver {
     }
   }
 
-  getHosSegments24(nowMs){
-    const DAY_MS = 24*3600*1000;
-    const startMs = Math.max(0, nowMs - DAY_MS);
+  getHosSegmentsRange(startMs, endMs){
     const evs = [];
     if (!this.hosLog.length){
-      return [{ start: 24-0.25, end: 24, status: 'OFF' }];
+      const hrs = Math.max(0, (endMs - startMs)/3600000);
+      return [{ start: Math.max(0, hrs - 0.25), end: hrs, status: 'OFF' }];
     }
     let statusAtStart = this.hosLog[0].status;
     for (const ev of this.hosLog){ if (ev.tMs <= startMs) statusAtStart = ev.status; else break; }
     evs.push({ tMs: startMs, status: statusAtStart });
-    for (const ev of this.hosLog){ if (ev.tMs > startMs && ev.tMs < nowMs) evs.push({ tMs: ev.tMs, status: ev.status }); }
-    evs.push({ tMs: nowMs, status: evs.length ? evs[evs.length-1].status : statusAtStart });
+    for (const ev of this.hosLog){ if (ev.tMs > startMs && ev.tMs < endMs) evs.push({ tMs: ev.tMs, status: ev.status }); }
+    evs.push({ tMs: endMs, status: evs.length ? evs[evs.length-1].status : statusAtStart });
     const segs = [];
     for (let i=0;i<evs.length-1;i++){
       const a = evs[i], b = evs[i+1];
@@ -187,6 +186,12 @@ export class Driver {
       if (endH > startH) segs.push({ start: startH, end: endH, status: a.status });
     }
     return segs;
+  }
+
+  getHosSegments24(nowMs){
+    const DAY_MS = 24*3600*1000;
+    const startMs = Math.max(0, nowMs - DAY_MS);
+    return this.getHosSegmentsRange(startMs, nowMs);
   }
 
   finishTrip(end){

--- a/src/ui_game.js
+++ b/src/ui_game.js
@@ -622,7 +622,16 @@ export const UI = {
 
     // Data
     const offsetMs = (UI._hosDayOffset || 0) * 24 * 3600 * 1000;
-    let segs = (d.getHosSegments24 ? d.getHosSegments24(Game.getSimNow().getTime() - offsetMs) : []);
+    const now = Game.getSimNow();
+    const todayStart = new Date(now.getFullYear(), now.getMonth(), now.getDate()).getTime();
+    const startMs = todayStart - offsetMs;
+    const endMs = UI._hosDayOffset ? (startMs + 24 * 3600 * 1000) : now.getTime();
+    let segs = [];
+    if (d.getHosSegmentsRange) {
+      segs = d.getHosSegmentsRange(startMs, endMs);
+    } else if (d.getHosSegments24) {
+      segs = d.getHosSegments24(endMs);
+    }
     if (!segs.length) segs = UI._getHosSegments(d);
     if (!segs.length){
       ctx.fillStyle = '#888';


### PR DESCRIPTION
## Summary
- add generic HOS segment range helper to Driver
- draw HOS chart based on midnight-aligned days so logs don't scroll between days

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68c6e881b7b48332bc4426cc046cf40c