### PR TITLE
Hide rest areas and truck stops by default

### DIFF
--- a/src/ui_game.js
+++ b/src/ui_game.js
@@ -43,7 +43,7 @@ const TrailerPriceRanges = {
 export const UI = {
   _hosDayOffset: 0,
   _hirePage: 0,
-  legend:{ showHQ:true, showSmallYards:true, showLargeYards:true, showWarehouses:true, showTruckStops:true, showRestAreas:true },
+  legend:{ showHQ:true, showSmallYards:true, showLargeYards:true, showWarehouses:true, showTruckStops:false, showRestAreas:false },
   _ensurePlus15Button(){ const hud=document.querySelector('#timeHud .clock')||document.getElementById('timeHud'); if(!hud) return; if(document.getElementById('btnPlus15')) return; const btn=document.createElement('button'); btn.id='btnPlus15'; btn.className='btn'; btn.title='Advance 15 sim minutes'; btn.textContent='+15m'; btn.onclick=()=>{ Game.jump(15*60*1000); UI.updateTimeHUD(); }; const b4=hud.querySelector('button[onclick*="Game.resume(4)"]'); if(b4&&b4.parentNode) b4.parentNode.insertBefore(btn, b4.nextSibling); else hud.appendChild(btn); },
   show(sel){ document.querySelectorAll('.panel').forEach(p=>p.style.display='none'); const el=document.querySelector(sel); if (el) el.style.display='block'; if(sel==='#panelCompany'){ try{ const s=document.getElementById('txtDriverSearch'); if(s) s.value=''; UI._companyNeedsListRefresh=true; UI.refreshCompany(); }catch(e){} } if(sel==='#panelBank'){ try{ UI.refreshBank(); }catch(e){} } if(sel==='#panelMarket'){ try{ UI.renderMarket(); }catch(e){} } if(sel==='#panelEquipment'){ try{ UI.refreshEquipment(); }catch(e){} } if(sel==='#panelProperties'){ try{ UI.refreshProperties(); }catch(e){} } },
   overlay(sel) {


### PR DESCRIPTION
## Summary
- Prevent rest area and truck stop layers from displaying on initial load

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68c6eac2b5e48332b43d70fd00f9d793