### PR TITLE
Enforce mandatory rest stops after 11 hours of driving

### DIFF
--- a/src/driver.js
+++ b/src/driver.js
@@ -42,6 +42,7 @@ export class Driver {
       this._hosPausedStartMs = null;
       this._hosLastTickMs = null;
       this.hosLog = [];
+      this._sleepUntil = null;
       this._hosLastStatus = null;
     } else {
       // Backward compatibility (old: name, lat, lng, color)
@@ -68,6 +69,7 @@ export class Driver {
       this.visible = true;
       this.hos = Array.from({length:7}, ()=>Math.floor(4 + Math.random()*7));
       this.hosLog = [];
+      this._sleepUntil = null;
       this._hosLastStatus = null;
     }
   }


### PR DESCRIPTION
## Summary
- add `findNearestStop` utility to locate nearby truck stops or rest areas
- reset drivers to Sleeper status and pause loads for 10 hours when 11-hour limit is hit
- store sleep state in Driver and support serialization

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68c6f3b289748332af400d6beb7d6f8c