### PR TITLE
Enforce 11-hour driving limit with automatic rest stops

### DIFF
--- a/src/ui_game.js
+++ b/src/ui_game.js
@@ -1,7 +1,7 @@
 import { Colors } from './colors.js';
 import { Driver } from './driver.js';
 import { Router } from './router.js';
-import { fmtETA } from './utils.js';
+import { fmtETA, findNearestStop } from './utils.js';
 import { cityByName, CityGroups } from './data/cities.js';
 import { DriverProfiles } from './data/driver_profiles.js';
 import { drawnItems, drawControl, clearNonOverrideDrawings, currentDrawnPolylineLatLngs, showCompletedRoutes, completedRoutesGroup, showOverridePolyline, refreshCompletedRoutes, setShowCompletedRoutes } from './drawing.js';
@@ -1234,6 +1234,7 @@ export const Game = {
     const makeLoadRow = (overrides) => ({
       id: crypto.randomUUID(),
       driverId: d.id, driverName: d.name, color: d.color,
+      pauseMs: 0,
       ...overrides
     });
 
@@ -1274,22 +1275,42 @@ export const Game = {
 
   update(){ const realNow=performance.now(); if(!this.paused) this._simElapsedMs += (realNow - this._realLast)*this.speed; this._realLast = realNow; const now=this.getSimNow().getTime();
     for (const d of this.drivers) {
-      try{ d.syncHosLog(now); }catch(e){}
-      if (d.status === 'On Trip') {
-        const ld = this.loads.find(l => l.id === d.currentLoadId);
-        if (!ld) continue;
-        const t = (now - ld.startTime) / ld.etaMs;
+      try{ d.syncHosLog(now); d.applyHosTick(now); }catch(e){}
+      const ld = this.loads.find(l => l.id === d.currentLoadId);
+      if (d.status === 'Sleeper' && d.sleepUntil && ld) {
+        ld.pauseMs = (ld.pauseMsBase || 0) + (now - (ld.pauseStartMs || now));
+        if (now >= d.sleepUntil) {
+          d.status = 'On Trip';
+          d.sleepUntil = null;
+          ld.pauseMs = (ld.pauseMsBase || 0) + (now - ld.pauseStartMs);
+          ld.pauseMsBase = ld.pauseMs;
+          ld.pauseStartMs = null;
+        }
+        continue;
+      }
+      if (d.status === 'On Trip' && ld) {
+        const legal = d.isDrivingLegal(now);
+        if (!legal.ok && legal.reason && legal.reason.includes('10-hour break')) {
+          const stop = findNearestStop(d.lat, d.lng, this.truckStops, this.restAreas);
+          if (stop) d.setPosition(stop.lat, stop.lng);
+          d.status = 'Sleeper';
+          d.sleepUntil = now + 10*3600*1000;
+          ld.pauseMsBase = ld.pauseMs || 0;
+          ld.pauseStartMs = now;
+          continue;
+        }
+        const t = (now - ld.startTime - (ld.pauseMs || 0)) / ld.etaMs;
         if (t >= 1) {
           d.finishTrip(ld.end);
-            if (ld.kind === 'Deadhead' && d._pendingMainLeg) {
-              // Mark the deadhead leg as complete so the driver can take new loads
-              ld.status = 'Delivered';
-              const { route, mainMiles, etaMainMs, profit, originName, destName } = d._pendingMainLeg;
-              const mainLoad = {
-                id: crypto.randomUUID(),
-                driverId: d.id, driverName: d.name, color: d.color,
-                kind: 'Main',
-                originName, destName,
+          if (ld.kind === 'Deadhead' && d._pendingMainLeg) {
+            // Mark the deadhead leg as complete so the driver can take new loads
+            ld.status = 'Delivered';
+            const { route, mainMiles, etaMainMs, profit, originName, destName } = d._pendingMainLeg;
+            const mainLoad = {
+              id: crypto.randomUUID(),
+              driverId: d.id, driverName: d.name, color: d.color,
+              kind: 'Main',
+              originName, destName,
               start: route.path[0], end: route.path[route.path.length-1],
               miles: mainMiles, startTime: Game.getSimNow().getTime(),
               etaMs: etaMainMs, status: 'En Route', profit

--- a/src/utils.js
+++ b/src/utils.js
@@ -23,3 +23,27 @@ export function fmtETA(ms){
   const h=Math.floor(s/3600), m=Math.floor((s%3600)/60);
   return `${h}h ${m}m`;
 }
+
+export function findNearestStop(lat, lng, truckStops = [], restAreas = []) {
+  let nearest = null;
+  let minDist = Infinity;
+  const consider = (sLat, sLng, name, type) => {
+    const dist = haversineMiles({ lat, lng }, { lat: sLat, lng: sLng });
+    if (dist < minDist) {
+      minDist = dist;
+      nearest = { lat: sLat, lng: sLng, name, type };
+    }
+  };
+  for (const ts of truckStops) {
+    const [sLat, sLng] = ts.coordinates || [];
+    if (sLat == null || sLng == null) continue;
+    consider(sLat, sLng, ts.name, 'Truck Stop');
+  }
+  for (const ra of restAreas) {
+    const sLat = ra.latitude ?? ra.lat;
+    const sLng = ra.longitude ?? ra.lng;
+    if (sLat == null || sLng == null) continue;
+    consider(sLat, sLng, ra.name, 'Rest Area');
+  }
+  return nearest;
+}

--- a/test/utils.test.js
+++ b/test/utils.test.js
@@ -1,6 +1,6 @@
 import test from 'node:test';
 import assert from 'node:assert/strict';
-import { haversineMiles, fmtETA } from '../src/utils.js';
+import { haversineMiles, fmtETA, findNearestStop } from '../src/utils.js';
 
 test('haversineMiles computes distance at equator for 1 degree', () => {
   const dist = haversineMiles({lat:0, lng:0}, {lat:0, lng:1});
@@ -10,4 +10,12 @@ test('haversineMiles computes distance at equator for 1 degree', () => {
 test('fmtETA formats hours and minutes', () => {
   const result = fmtETA(3720000);
   assert.equal(result, '1h 2m');
+});
+
+test('findNearestStop selects closest facility', () => {
+  const truckStops = [{ name: 'StopA', coordinates: [0, 0] }];
+  const restAreas = [{ name: 'RestB', latitude: 0.5, longitude: 0.5 }];
+  const res = findNearestStop(0.1, 0.1, truckStops, restAreas);
+  assert.equal(res.name, 'StopA');
+  assert.equal(res.type, 'Truck Stop');
 });


### PR DESCRIPTION
## Summary
- add helper to locate nearest truck stop or rest area
- extend driver HOS tracking with sleep support
- pause loads and send drivers to rest after 11 hours of driving
- trigger rest whenever a violation requires a 10-hour break

## Testing
- `npm test` *(fails: command not found: npm)*


------
https://chatgpt.com/codex/tasks/task_e_68c6f3b289748332af400d6beb7d6f8c