### PR TITLE
Enforce 11-hour HOS limit with automatic rest stops

### DIFF
--- a/src/driver.js
+++ b/src/driver.js
@@ -43,6 +43,7 @@ export class Driver {
       this._hosLastTickMs = null;
       this.hosLog = [];
       this._hosLastStatus = null;
+      this.breakUntilMs = null;
     } else {
       // Backward compatibility (old: name, lat, lng, color)
       const name = String(arg1 || '').trim() || 'Driver';
@@ -69,6 +70,7 @@ export class Driver {
       this.hos = Array.from({length:7}, ()=>Math.floor(4 + Math.random()*7));
       this.hosLog = [];
       this._hosLastStatus = null;
+      this.breakUntilMs = null;
     }
   }
   get name(){ return (this.firstName + ' ' + this.lastName).trim(); }
@@ -96,10 +98,11 @@ export class Driver {
     this.setPosition(p.lat, p.lng);
   }
   _hosStatus(){
-    if (this.currentLoadId) return 'D';
     const s = this.status || 'Idle';
     if (s === 'SB' || s === 'Sleeper') return 'SB';
     if (s === 'OFF' || s === 'Off Duty') return 'OFF';
+    if (s === 'On Duty') return 'ON';
+    if (s === 'On Trip') return 'D';
     return 'OFF';
   }
   _appendHosSegment(status, startHour, endHour){
@@ -147,9 +150,9 @@ export class Driver {
   }
 
   _currentHosStatus(){
-    if (this.currentLoadId || this.status === 'On Trip') return 'D';
     if (this.status === 'SB' || this.status === 'Sleeper') return 'SB';
     if (this.status === 'On Duty') return 'ON';
+    if (this.status === 'On Trip') return 'D';
     return 'OFF';
   }
 

--- a/src/ui_game.js
+++ b/src/ui_game.js
@@ -1,7 +1,7 @@
 import { Colors } from './colors.js';
 import { Driver } from './driver.js';
 import { Router } from './router.js';
-import { fmtETA } from './utils.js';
+import { fmtETA, haversineMiles } from './utils.js';
 import { cityByName, CityGroups } from './data/cities.js';
 import { DriverProfiles } from './data/driver_profiles.js';
 import { drawnItems, drawControl, clearNonOverrideDrawings, currentDrawnPolylineLatLngs, showCompletedRoutes, completedRoutesGroup, showOverridePolyline, refreshCompletedRoutes, setShowCompletedRoutes } from './drawing.js';
@@ -985,7 +985,8 @@ export const Game = {
       path:d.path,cumMiles:d.cumMiles,hos:d.hos,hosSegments:d.hosSegments,hosDay:d.hosDay,
       hosDutyStartMs:d.hosDutyStartMs,hosDriveSinceReset:d.hosDriveSinceReset,
       hosDriveSinceLastBreak:d.hosDriveSinceLastBreak,hosOffStreak:d.hosOffStreak,hosLog:d.hosLog,
-      _pendingMainLeg:d._pendingMainLeg
+      _pendingMainLeg:d._pendingMainLeg,
+      breakUntilMs:d.breakUntilMs
     };
   },
   serialize(){
@@ -1059,6 +1060,7 @@ export const Game = {
         drv.hosOffStreak=dd.hosOffStreak||0;
         drv.hosLog=dd.hosLog||[];
         drv._pendingMainLeg=dd._pendingMainLeg||null;
+        drv.breakUntilMs=dd.breakUntilMs||null;
         if(drv.status==='On Trip' && Array.isArray(dd.path)){
           drv.startTripPolyline(dd.path, dd.currentLoadId);
           drv.cumMiles=dd.cumMiles;
@@ -1272,36 +1274,69 @@ export const Game = {
     UI.refreshDispatch();
   },
 
+  nearestStop(lat, lng){
+    let best=null, bestDist=Infinity;
+    const pos={lat,lng};
+    const add=(a,b)=>{ const dist=haversineMiles(pos,{lat:a,lng:b}); if(dist<bestDist){ bestDist=dist; best={lat:a,lng:b}; } };
+    for(const ts of this.truckStops){
+      const [a,b]=ts.coordinates||[]; if(a!=null&&b!=null) add(a,b);
+    }
+    for(const ra of this.restAreas){
+      const a=ra.latitude??ra.lat, b=ra.longitude??ra.lng; if(a!=null&&b!=null) add(a,b);
+    }
+    return best;
+  },
+
+  _beginSleeperBreak(d, ld, now){
+    const stop=this.nearestStop(d.lat, d.lng);
+    if(stop){ d.setPosition(stop.lat, stop.lng); }
+    d.status='SB';
+    d.breakUntilMs=now + 10*3600*1000;
+    if(ld){ ld.pauseMs=(ld.pauseMs||0) + 10*3600*1000; ld.status='Paused'; }
+    UI.refreshDispatch();
+  },
+
   update(){ const realNow=performance.now(); if(!this.paused) this._simElapsedMs += (realNow - this._realLast)*this.speed; this._realLast = realNow; const now=this.getSimNow().getTime();
     for (const d of this.drivers) {
-      try{ d.syncHosLog(now); }catch(e){}
-      if (d.status === 'On Trip') {
-        const ld = this.loads.find(l => l.id === d.currentLoadId);
-        if (!ld) continue;
-        const t = (now - ld.startTime) / ld.etaMs;
-        if (t >= 1) {
+      try{ d.syncHosLog(now); d.applyHosTick(now); }catch(e){}
+      const ld=this.loads.find(l=>l.id===d.currentLoadId);
+      if(d.status==='SB' && d.breakUntilMs){
+        if(now>=d.breakUntilMs){
+          d.status='On Trip';
+          d.breakUntilMs=null;
+          if(ld){ ld.status='En Route'; }
+          UI.refreshDispatch();
+        } else {
+          continue;
+        }
+      }
+      if(d.status==='On Trip'){
+        const legal=d.isDrivingLegal(now);
+        if(!legal.ok){ this._beginSleeperBreak(d, ld, now); continue; }
+        if(!ld) continue;
+        const t=(now - ld.startTime) / ld.etaMs;
+        if(t >= 1){
           d.finishTrip(ld.end);
-            if (ld.kind === 'Deadhead' && d._pendingMainLeg) {
-              // Mark the deadhead leg as complete so the driver can take new loads
-              ld.status = 'Delivered';
-              const { route, mainMiles, etaMainMs, profit, originName, destName } = d._pendingMainLeg;
-              const mainLoad = {
-                id: crypto.randomUUID(),
-                driverId: d.id, driverName: d.name, color: d.color,
-                kind: 'Main',
-                originName, destName,
+          if(ld.kind==='Deadhead' && d._pendingMainLeg){
+            ld.status='Delivered';
+            const { route, mainMiles, etaMainMs, profit, originName, destName } = d._pendingMainLeg;
+            const mainLoad={
+              id: crypto.randomUUID(),
+              driverId: d.id, driverName: d.name, color: d.color,
+              kind:'Main',
+              originName, destName,
               start: route.path[0], end: route.path[route.path.length-1],
               miles: mainMiles, startTime: Game.getSimNow().getTime(),
-              etaMs: etaMainMs, status: 'En Route', profit
+              etaMs: etaMainMs, status:'En Route', profit
             };
             this.loads.push(mainLoad);
-            d._pendingMainLeg = null;
+            d._pendingMainLeg=null;
             d.startTripPolyline(route.path, mainLoad.id);
             UI.refreshDispatch();
-          } else {
+          }else{
             this.completeLoad(ld);
           }
-        } else {
+        }else{
           d.tick(now, ld);
         }
       }


### PR DESCRIPTION
## Summary
- track sleeper-break end time on each Driver
- detect 11-hour driving limit and route drivers to nearest rest area or truck stop
- pause loads for 10-hour sleeper berth breaks before resuming travel
- log sleeper-berth time as off-duty so drive hours reset correctly

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68c6fb68ac088332ac339ae483face63