### PR TITLE
Enforce 11-hour HOS limit with automatic rest stops

### DIFF
--- a/src/driver.js
+++ b/src/driver.js
@@ -1,6 +1,9 @@
 import { map } from './map.js';
 import { cumulativeMiles, interpolateAlong } from './utils.js';
 
+const HOS_STEP_MS = 60*1000; // 1-minute resolution
+const HOS_STEP_HR = HOS_STEP_MS / 3600000;
+
 /** Driver now supports full profile data. Backward-compatible with old constructor. */
 let _driverIdCounter = 1;
 export class Driver {
@@ -43,6 +46,7 @@ export class Driver {
       this._hosLastTickMs = null;
       this.hosLog = [];
       this._hosLastStatus = null;
+      this.breakUntilMs = null;
     } else {
       // Backward compatibility (old: name, lat, lng, color)
       const name = String(arg1 || '').trim() || 'Driver';
@@ -69,6 +73,7 @@ export class Driver {
       this.hos = Array.from({length:7}, ()=>Math.floor(4 + Math.random()*7));
       this.hosLog = [];
       this._hosLastStatus = null;
+      this.breakUntilMs = null;
     }
   }
   get name(){ return (this.firstName + ' ' + this.lastName).trim(); }
@@ -96,10 +101,11 @@ export class Driver {
     this.setPosition(p.lat, p.lng);
   }
   _hosStatus(){
-    if (this.currentLoadId) return 'D';
     const s = this.status || 'Idle';
     if (s === 'SB' || s === 'Sleeper') return 'SB';
     if (s === 'OFF' || s === 'Off Duty') return 'OFF';
+    if (s === 'On Trip' || s === 'Driving') return 'D';
+    if (this.currentLoadId) return 'D';
     return 'OFF';
   }
   _appendHosSegment(status, startHour, endHour){
@@ -112,29 +118,31 @@ export class Driver {
     this.hosSegments.push({start, end, status});
   }
   applyHosTick(nowMs){
-    const stepMs = 15*60*1000;
+    const stepMs = HOS_STEP_MS;
+    const stepHr = HOS_STEP_HR;
     if (!this._hosLastTickMs){ this._hosLastTickMs = nowMs - stepMs; }
     for (let t=this._hosLastTickMs+stepMs; t<=nowMs; t+=stepMs){
       const st = this._hosStatus();
       const dt = new Date(t);
       const hr = dt.getHours() + dt.getMinutes()/60;
-      this._appendHosSegment(st, hr-0.25, hr);
+      this._appendHosSegment(st, hr-stepHr, hr);
       if (st==='OFF' || st==='SB'){
-        this.hosOffStreak += 0.25;
-        this.hosDriveSinceLastBreak = Math.max(0, this.hosDriveSinceLastBreak - 0.25);
+        this.hosOffStreak += stepHr;
+        this.hosDriveSinceLastBreak = Math.max(0, this.hosDriveSinceLastBreak - stepHr);
         if (this.hosOffStreak >= 10){ this.hosDutyStartMs=null; this.hosDriveSinceReset=0; }
       } else {
         this.hosOffStreak = 0;
         if (!this.hosDutyStartMs) this.hosDutyStartMs = t;
-        if (st==='D'){ this.hosDriveSinceReset += 0.25; this.hosDriveSinceLastBreak += 0.25; }
+        if (st==='D'){ this.hosDriveSinceReset += stepHr; this.hosDriveSinceLastBreak += stepHr; }
       }
       this._hosLastTickMs = t;
     }
   }
-  isDrivingLegal(nowMs){
+  isDrivingLegal(nowMs, elapsedDriveHrs = 0){
     const dutyStart = this.hosDutyStartMs;
     const onDutyHrs = dutyStart ? Math.max(0, (nowMs - dutyStart)/3600000) : 0;
-    if (this.hosDriveSinceReset >= 11){
+    const driveHrs = Math.max(this.hosDriveSinceReset, elapsedDriveHrs);
+    if (driveHrs >= 11){
       return { ok:false, reason:'11-hour driving limit reached. Take a 10-hour break.' };
     }
     if (dutyStart && onDutyHrs >= 14){
@@ -147,9 +155,12 @@ export class Driver {
   }
 
   _currentHosStatus(){
-    if (this.currentLoadId || this.status === 'On Trip') return 'D';
-    if (this.status === 'SB' || this.status === 'Sleeper') return 'SB';
-    if (this.status === 'On Duty') return 'ON';
+    const s = this.status || 'Idle';
+    if (s === 'SB' || s === 'Sleeper') return 'SB';
+    if (s === 'On Trip' || s === 'Driving') return 'D';
+    if (s === 'On Duty') return 'ON';
+    if (s === 'OFF' || s === 'Off Duty') return 'OFF';
+    if (this.currentLoadId) return 'D';
     return 'OFF';
   }
 
@@ -157,7 +168,7 @@ export class Driver {
     const s = this._currentHosStatus();
     const last = this.hosLog.length ? this.hosLog[this.hosLog.length-1].status : null;
     if (!this.hosLog.length){
-      this.hosLog.push({ tMs: Math.max(0, nowMs - 15*60*1000), status: s });
+      this.hosLog.push({ tMs: Math.max(0, nowMs - HOS_STEP_MS), status: s });
       this._hosLastStatus = s;
       return;
     }
@@ -171,7 +182,7 @@ export class Driver {
     const evs = [];
     if (!this.hosLog.length){
       const hrs = Math.max(0, (endMs - startMs)/3600000);
-      return [{ start: Math.max(0, hrs - 0.25), end: hrs, status: 'OFF' }];
+      return [{ start: Math.max(0, hrs - HOS_STEP_HR), end: hrs, status: 'OFF' }];
     }
     let statusAtStart = this.hosLog[0].status;
     for (const ev of this.hosLog){ if (ev.tMs <= startMs) statusAtStart = ev.status; else break; }

--- a/src/ui_game.js
+++ b/src/ui_game.js
@@ -1,7 +1,7 @@
 import { Colors } from './colors.js';
 import { Driver } from './driver.js';
 import { Router } from './router.js';
-import { fmtETA } from './utils.js';
+import { fmtETA, haversineMiles } from './utils.js';
 import { cityByName, CityGroups } from './data/cities.js';
 import { DriverProfiles } from './data/driver_profiles.js';
 import { drawnItems, drawControl, clearNonOverrideDrawings, currentDrawnPolylineLatLngs, showCompletedRoutes, completedRoutesGroup, showOverridePolyline, refreshCompletedRoutes, setShowCompletedRoutes } from './drawing.js';
@@ -985,7 +985,8 @@ export const Game = {
       path:d.path,cumMiles:d.cumMiles,hos:d.hos,hosSegments:d.hosSegments,hosDay:d.hosDay,
       hosDutyStartMs:d.hosDutyStartMs,hosDriveSinceReset:d.hosDriveSinceReset,
       hosDriveSinceLastBreak:d.hosDriveSinceLastBreak,hosOffStreak:d.hosOffStreak,hosLog:d.hosLog,
-      _pendingMainLeg:d._pendingMainLeg
+      _pendingMainLeg:d._pendingMainLeg,
+      breakUntilMs:d.breakUntilMs
     };
   },
   serialize(){
@@ -1059,6 +1060,7 @@ export const Game = {
         drv.hosOffStreak=dd.hosOffStreak||0;
         drv.hosLog=dd.hosLog||[];
         drv._pendingMainLeg=dd._pendingMainLeg||null;
+        drv.breakUntilMs=dd.breakUntilMs||null;
         if(drv.status==='On Trip' && Array.isArray(dd.path)){
           drv.startTripPolyline(dd.path, dd.currentLoadId);
           drv.cumMiles=dd.cumMiles;
@@ -1272,39 +1274,77 @@ export const Game = {
     UI.refreshDispatch();
   },
 
+  nearestStop(lat, lng){
+    let best=null, bestDist=Infinity;
+    const pos={lat,lng};
+    const add=(a,b)=>{ const dist=haversineMiles(pos,{lat:a,lng:b}); if(dist<bestDist){ bestDist=dist; best={lat:a,lng:b}; } };
+    for(const ts of this.truckStops){
+      const [a,b]=ts.coordinates||[]; if(a!=null&&b!=null) add(a,b);
+    }
+    for(const ra of this.restAreas){
+      const a=ra.latitude??ra.lat, b=ra.longitude??ra.lng; if(a!=null&&b!=null) add(a,b);
+    }
+    return best;
+  },
+
+  _beginSleeperBreak(d, ld, now){
+    const stop=this.nearestStop(d.lat, d.lng);
+    if(stop){ d.setPosition(stop.lat, stop.lng); }
+    d.status='SB';
+    d.breakUntilMs=now + 10*3600*1000;
+    if(ld){ ld.pauseMs=(ld.pauseMs||0) + 10*3600*1000; ld.status='Paused'; }
+    UI.refreshDispatch();
+  },
+
+  _updateDriver(d, now){
+    try{ d.syncHosLog(now); d.applyHosTick(now); }catch(e){}
+    const ld=this.loads.find(l=>l.id===d.currentLoadId);
+    if(d.status==='SB' && d.breakUntilMs){
+      if(now>=d.breakUntilMs){
+        d.status='On Trip';
+        d.breakUntilMs=null;
+        if(ld){ ld.status='En Route'; }
+        UI.refreshDispatch();
+      } else {
+        return;
+      }
+    }
+    if(d.status==='On Trip'){
+      const elapsed = ld ? Math.max(0, (now - ld.startTime - (ld.pauseMs||0)) / 3600000) : 0;
+      const legal=d.isDrivingLegal(now, elapsed);
+      if(!legal.ok){ this._beginSleeperBreak(d, ld, now); return; }
+      if(!ld) return;
+      const t=(now - ld.startTime) / ld.etaMs;
+      if(t >= 1){
+        d.finishTrip(ld.end);
+        if(ld.kind==='Deadhead' && d._pendingMainLeg){
+          ld.status='Delivered';
+          const { route, mainMiles, etaMainMs, profit, originName, destName } = d._pendingMainLeg;
+          const mainLoad={
+            id: crypto.randomUUID(),
+            driverId: d.id, driverName: d.name, color: d.color,
+            kind:'Main',
+            originName, destName,
+            start: route.path[0], end: route.path[route.path.length-1],
+            miles: mainMiles, startTime: now,
+            etaMs: etaMainMs, status:'En Route', profit
+          };
+          this.loads.push(mainLoad);
+          d._pendingMainLeg=null;
+          d.startTripPolyline(route.path, mainLoad.id);
+          UI.refreshDispatch();
+        }else{
+          this.completeLoad(ld);
+        }
+      }else{
+        d.tick(now, ld);
+      }
+    }
+  },
+
   update(){ const realNow=performance.now(); if(!this.paused) this._simElapsedMs += (realNow - this._realLast)*this.speed; this._realLast = realNow; const now=this.getSimNow().getTime();
     for (const d of this.drivers) {
-      try{ d.syncHosLog(now); }catch(e){}
-      if (d.status === 'On Trip') {
-        const ld = this.loads.find(l => l.id === d.currentLoadId);
-        if (!ld) continue;
-        const t = (now - ld.startTime) / ld.etaMs;
-        if (t >= 1) {
-          d.finishTrip(ld.end);
-            if (ld.kind === 'Deadhead' && d._pendingMainLeg) {
-              // Mark the deadhead leg as complete so the driver can take new loads
-              ld.status = 'Delivered';
-              const { route, mainMiles, etaMainMs, profit, originName, destName } = d._pendingMainLeg;
-              const mainLoad = {
-                id: crypto.randomUUID(),
-                driverId: d.id, driverName: d.name, color: d.color,
-                kind: 'Main',
-                originName, destName,
-              start: route.path[0], end: route.path[route.path.length-1],
-              miles: mainMiles, startTime: Game.getSimNow().getTime(),
-              etaMs: etaMainMs, status: 'En Route', profit
-            };
-            this.loads.push(mainLoad);
-            d._pendingMainLeg = null;
-            d.startTripPolyline(route.path, mainLoad.id);
-            UI.refreshDispatch();
-          } else {
-            this.completeLoad(ld);
-          }
-        } else {
-          d.tick(now, ld);
-        }
-      }
+      this._updateDriver(d, now);
     }
     UI.refreshTablesLive();
   },
@@ -1316,9 +1356,14 @@ export const Game = {
     if (burn > 0) this.addCash(-burn, 'Daily overhead');
   }
   ,jump(ms){
-    this._simElapsedMs += Math.max(0, ms|0);
-    const now = this.getSimNow().getTime();
-    try { for (const d of this.drivers) { d.syncHosLog(now); d.applyHosTick(now); } } catch(e){}
+    let remaining = Math.max(0, ms|0);
+    while(remaining > 0){
+      const step = Math.min(remaining, 60*1000);
+      this._simElapsedMs += step;
+      const now = this.getSimNow().getTime();
+      for (const d of this.drivers){ this._updateDriver(d, now); }
+      remaining -= step;
+    }
     try {
       UI.refreshTablesLive();
       const sid = UI._companySelectedId;


### PR DESCRIPTION
## Summary
- track sleeper-break end time on each Driver
- detect 11-hour driving limit and route drivers to nearest rest area or truck stop
- pause loads for 10-hour sleeper berth breaks before resuming travel
- log sleeper-berth status even while a load is assigned so HOS timers reset correctly
- check HOS each simulated minute and during time jumps so breaks and limits trigger exactly
- fall back to elapsed trip time when HOS ticks are missing so the 11-hour limit applies on a driver's first run

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68c6fb68ac088332ac339ae483face63