### PR TITLE
Handle paused break time in load completion

### DIFF
--- a/src/ui_game.js
+++ b/src/ui_game.js
@@ -1,7 +1,7 @@
 import { Colors } from './colors.js';
 import { Driver } from './driver.js';
 import { Router } from './router.js';
-import { fmtETA, haversineMiles } from './utils.js';
+import { fmtETA, haversineMiles, loadProgress } from './utils.js';
 import { cityByName, CityGroups } from './data/cities.js';
 import { DriverProfiles } from './data/driver_profiles.js';
 import { drawnItems, drawControl, clearNonOverrideDrawings, currentDrawnPolylineLatLngs, showCompletedRoutes, completedRoutesGroup, showOverridePolyline, refreshCompletedRoutes, setShowCompletedRoutes } from './drawing.js';
@@ -1313,7 +1313,7 @@ export const Game = {
       const legal=d.isDrivingLegal(now);
       if(!legal.ok){ this._beginSleeperBreak(d, ld, now); return; }
       if(!ld) return;
-      const t=(now - ld.startTime) / ld.etaMs;
+      const t = loadProgress(ld, now);
       if(t >= 1){
         d.finishTrip(ld.end);
         if(ld.kind==='Deadhead' && d._pendingMainLeg){

--- a/src/utils.js
+++ b/src/utils.js
@@ -23,3 +23,8 @@ export function fmtETA(ms){
   const h=Math.floor(s/3600), m=Math.floor((s%3600)/60);
   return `${h}h ${m}m`;
 }
+
+export function loadProgress(load, now){
+  const paused = load.pauseMs || 0;
+  return (now - load.startTime - paused) / load.etaMs;
+}

--- a/test/utils.test.js
+++ b/test/utils.test.js
@@ -1,6 +1,6 @@
 import test from 'node:test';
 import assert from 'node:assert/strict';
-import { haversineMiles, fmtETA } from '../src/utils.js';
+import { haversineMiles, fmtETA, loadProgress } from '../src/utils.js';
 
 test('haversineMiles computes distance at equator for 1 degree', () => {
   const dist = haversineMiles({lat:0, lng:0}, {lat:0, lng:1});
@@ -10,4 +10,10 @@ test('haversineMiles computes distance at equator for 1 degree', () => {
 test('fmtETA formats hours and minutes', () => {
   const result = fmtETA(3720000);
   assert.equal(result, '1h 2m');
+});
+
+test('loadProgress subtracts pause duration', () => {
+  const load = { startTime: 0, etaMs: 1000, pauseMs: 200 };
+  const t = loadProgress(load, 1000);
+  assert.equal(t, 0.8);
 });


### PR DESCRIPTION
## Summary
- account for paused time when computing load progress
- expose `loadProgress` helper
- add tests for pause-aware progress calculation

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68c72817c2c083328cfacd1f2a6f5e60