### PR TITLE
Add scheduled 30-minute driving break

### DIFF
--- a/src/ui_game.js
+++ b/src/ui_game.js
@@ -986,7 +986,8 @@ export const Game = {
       hosDutyStartMs:d.hosDutyStartMs,hosDriveSinceReset:d.hosDriveSinceReset,
       hosDriveSinceLastBreak:d.hosDriveSinceLastBreak,hosOffStreak:d.hosOffStreak,hosLog:d.hosLog,
       _pendingMainLeg:d._pendingMainLeg,
-      breakUntilMs:d.breakUntilMs
+      breakUntilMs:d.breakUntilMs,
+      nextBreakAtMs:d.nextBreakAtMs
     };
   },
   serialize(){
@@ -1061,6 +1062,7 @@ export const Game = {
         drv.hosLog=dd.hosLog||[];
         drv._pendingMainLeg=dd._pendingMainLeg||null;
         drv.breakUntilMs=dd.breakUntilMs||null;
+        drv.nextBreakAtMs=dd.nextBreakAtMs||null;
         if(drv.status==='On Trip' && Array.isArray(dd.path)){
           drv.startTripPolyline(dd.path, dd.currentLoadId);
           drv.cumMiles=dd.cumMiles;
@@ -1296,22 +1298,39 @@ export const Game = {
     UI.refreshDispatch();
   },
 
+  _beginShortBreak(d, ld, now){
+    const stop=this.nearestStop(d.lat, d.lng);
+    if(stop){ d.setPosition(stop.lat, stop.lng); }
+    d.status='OFF';
+    d.breakUntilMs = now + 30*60*1000;
+    if(ld){ ld.pauseMs=(ld.pauseMs||0) + 30*60*1000; ld.status='Paused'; }
+    UI.refreshDispatch();
+  },
+
   _updateDriver(d, now){
     try{ d.syncHosLog(now); d.applyHosTick(now); }catch(e){}
     const ld=this.loads.find(l=>l.id===d.currentLoadId);
-    if(d.status==='SB' && d.breakUntilMs){
+    if((d.status==='SB' || d.status==='OFF') && d.breakUntilMs){
       if(now>=d.breakUntilMs){
-        d.status='On Trip';
         d.breakUntilMs=null;
+        d.status = d.currentLoadId ? 'On Trip' : 'Idle';
         if(ld){ ld.status='En Route'; }
+        d.hosDriveSinceLastBreak=0;
+        d.nextBreakAtMs = now + (5 + Math.random()*3)*3600*1000;
         UI.refreshDispatch();
       } else {
         return;
       }
     }
     if(d.status==='On Trip'){
+      if(!d.nextBreakAtMs){ d.nextBreakAtMs = now + (5 + Math.random()*3)*3600*1000; }
+      if(d.nextBreakAtMs && now>=d.nextBreakAtMs){ this._beginShortBreak(d, ld, now); return; }
       const legal=d.isDrivingLegal(now);
-      if(!legal.ok){ this._beginSleeperBreak(d, ld, now); return; }
+      if(!legal.ok){
+        if(legal.reason.startsWith('30-minute break')){ this._beginShortBreak(d, ld, now); }
+        else { this._beginSleeperBreak(d, ld, now); }
+        return;
+      }
       if(!ld) return;
       const t = loadProgress(ld, now);
       if(t >= 1){


### PR DESCRIPTION
## Summary
- track short-break state and next break time in Driver HOS data
- schedule random 30-minute off-duty break 5–8 hours into trips
- enforce 30-minute break after 8h driving and resume trips automatically

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68c72ca2c400833293a81d37662c62c3