### PR TITLE
Implement 34-hour break after 70 hours of driving

### DIFF
--- a/src/driver.js
+++ b/src/driver.js
@@ -40,6 +40,7 @@ export class Driver {
       this.hosDay = null;
       this.hosDutyStartMs = null;
       this.hosDriveSinceReset = 0;
+      this.hosCycleDrive = d.hosCycleDrive || 0;
       this.hosDriveSinceLastBreak = 0;
       this.hosOffStreak = 0;
       this._shortBreakAccum = 0;
@@ -77,6 +78,7 @@ export class Driver {
       this.hosDay = null;
       this.hosDutyStartMs = null;
       this.hosDriveSinceReset = 0;
+      this.hosCycleDrive = 0;
       this.hosDriveSinceLastBreak = 0;
       this.hosOffStreak = 0;
       this._shortBreakAccum = 0;
@@ -143,11 +145,12 @@ export class Driver {
         this._shortBreakAccum += stepHr;
         if (this._shortBreakAccum >= 0.5){ this.hosDriveSinceLastBreak = 0; }
         if (this.hosOffStreak >= 10){ this.hosDutyStartMs=null; this.hosDriveSinceReset=0; }
+        if (this.hosOffStreak >= 34){ this.hosCycleDrive = 0; }
       } else {
         this.hosOffStreak = 0;
         this._shortBreakAccum = 0;
         if (!this.hosDutyStartMs) this.hosDutyStartMs = t;
-        if (st==='D'){ this.hosDriveSinceReset += stepHr; this.hosDriveSinceLastBreak += stepHr; }
+        if (st==='D'){ this.hosDriveSinceReset += stepHr; this.hosDriveSinceLastBreak += stepHr; this.hosCycleDrive += stepHr; }
       }
       this._hosLastTickMs = t;
     }
@@ -160,6 +163,9 @@ export class Driver {
     }
     if (dutyStart && onDutyHrs >= 14){
       return { ok:false, reason:'14-hour duty window expired. Take a 10-hour break.' };
+    }
+    if (this.hosCycleDrive >= 70){
+      return { ok:false, reason:'70-hour weekly limit reached. Take a 34-hour break.' };
     }
     if (this.hosDriveSinceLastBreak >= 8){
       return { ok:false, reason:'30-minute break required after 8h driving.' };

--- a/test/driver.test.js
+++ b/test/driver.test.js
@@ -1,0 +1,36 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+
+// Stub Leaflet and map for Node environment
+global.L = {
+  latLngBounds: () => ({ pad(){ return this; } }),
+  map: () => ({ setView(){ return this; }, removeLayer(){}, addLayer(){} }),
+  control: { zoom: () => ({ addTo(){} }) },
+  tileLayer: () => ({ addTo(){} }),
+  circleMarker: () => ({ addTo(){}, setLatLng(){} }),
+  polyline: () => ({ addTo(){}, setStyle(){} })
+};
+
+const { Driver } = await import('../src/driver.js');
+
+const MS = 3600 * 1000;
+
+test('70-hour limit requires 34-hour break', () => {
+  const d = new Driver('Test',0,0,'#000');
+  d.hosCycleDrive = 70;
+  d.hosDriveSinceReset = 0;
+  d.hosDutyStartMs = null;
+  d.hosDriveSinceLastBreak = 0;
+  const res = d.isDrivingLegal(Date.now());
+  assert.equal(res.ok, false);
+  assert.ok(res.reason.includes('70-hour'));
+});
+
+test('34h off resets weekly drive', () => {
+  const d = new Driver('Test',0,0,'#000');
+  d.hosCycleDrive = 70;
+  d.status = 'OFF';
+  d._hosLastTickMs = -60 * 1000;
+  d.applyHosTick(34 * MS);
+  assert.equal(d.hosCycleDrive, 0);
+});


### PR DESCRIPTION
## Summary
- Track cumulative weekly driving hours with `hosCycleDrive`
- Trigger a 34-hour sleeper break when the 70-hour limit is reached
- Persist cycle drive data and load it across sessions
- Test 70-hour limit enforcement and weekly reset

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68c733033ea883328ccd02f61058245b