### PR TITLE
Add announcement banners for load events

### DIFF
--- a/assets/css/styles.css
+++ b/assets/css/styles.css
@@ -413,3 +413,29 @@ bottom: 84px; z-index: 1200;}
 #pauseMenu .btn {
   width: 100%;
 }
+
+/* Announcement banners */
+.announce-container{
+  position:fixed;
+  top:12px;
+  left:50%;
+  transform:translateX(-50%);
+  display:flex;
+  flex-direction:column;
+  gap:8px;
+  z-index:1000;
+}
+
+.announce-banner{
+  background:#1b2832;
+  border:1px solid #2d3943;
+  color:#e9eef1;
+  padding:10px 14px;
+  border-radius:8px;
+  opacity:0;
+  transition:opacity .4s;
+}
+
+.announce-banner.show{
+  opacity:1;
+}

--- a/src/announcer.js
+++ b/src/announcer.js
@@ -1,0 +1,21 @@
+const DEFAULT_TIMEOUT = 20000;
+
+export function announce(msg, opts = {}) {
+  const { timeout = DEFAULT_TIMEOUT } = opts;
+  let container = document.getElementById('announce-container');
+  if (!container) {
+    container = document.createElement('div');
+    container.id = 'announce-container';
+    container.className = 'announce-container';
+    document.body.appendChild(container);
+  }
+  const banner = document.createElement('div');
+  banner.className = 'announce-banner';
+  banner.textContent = msg;
+  container.appendChild(banner);
+  requestAnimationFrame(() => banner.classList.add('show'));
+  setTimeout(() => {
+    banner.classList.remove('show');
+    setTimeout(() => banner.remove(), 500);
+  }, timeout);
+}

--- a/src/load_board.js
+++ b/src/load_board.js
@@ -6,6 +6,7 @@
 
 import * as CitiesMod from './data/cities.js';
 import * as Utils from './utils.js';
+import { announce } from './announcer.js';
 
 // Normalize exports
 const CITIES = (CitiesMod.Cities) || (CitiesMod.CityGroups ? CitiesMod.CityGroups.flatMap(g => g.items) : []);
@@ -272,15 +273,9 @@ function bookLoad(load, driverId){
   addBooked({ ...load, driverId, sid: SESSION_ID, bookedAt: new Date().toISOString() });
 
   if(typeof g.assignLoad==='function'){ try{ g.assignLoad(driverId, load); }catch(e){ console.warn('assignLoad error', e); } }
-  toast(`${load.origin.city}, ${load.origin.state} → ${load.dest.city}, ${load.dest.state} booked.`);
+  const driverName = d.name || `Driver ${driverId}`;
+  announce(`Booked under ${driverName}: ${load.origin.city}, ${load.origin.state} → ${load.dest.city}, ${load.dest.state}`);
 }
-
-function toast(msg){
-  let t=document.getElementById('lb-toast');
-  if(!t){ t=document.createElement('div'); t.id='lb-toast'; t.className='lb-toast'; document.body.appendChild(t); }
-  t.textContent=msg; t.classList.add('show'); setTimeout(()=>t.classList.remove('show'), 1800);
-}
-
 let _panel, _listEl, _mode='available';
 function setMode(mode){
   _mode=mode;

--- a/src/ui_game.js
+++ b/src/ui_game.js
@@ -8,6 +8,7 @@ import { drawnItems, drawControl, clearNonOverrideDrawings, currentDrawnPolyline
 import { OverrideStore } from './store.js';
 import { initLoadBoard, openLoadBoard } from './load_board.js';
 import { map } from './map.js';
+import { announce } from './announcer.js';
 
 // Catalog data for market
 const TruckCatalog = [
@@ -1275,6 +1276,9 @@ export const Game = {
     this.addCash(load.profit, `Delivered load ${load.originName} → ${load.destName}`);
     load.status = 'Delivered';
     UI.refreshDispatch();
+    const amt = load.profit.toLocaleString(undefined, { style: 'currency', currency: 'USD', maximumFractionDigits: 0 });
+    const driver = load.driverName || 'Driver';
+    announce(`${driver} completed load and earned ${amt}`);
   },
 
   nearestStop(lat, lng){


### PR DESCRIPTION
## Summary
- Introduce reusable `announce` helper to show top-of-screen banners
- Replace load-booked toast with banner including driver name
- Show banner when loads are completed with driver and earnings

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68c737c6fdf4833281f31e051ae7a941